### PR TITLE
fix: harden backend reliability for issue 607

### DIFF
--- a/cmd/tradingagent/debate_timeout_provider.go
+++ b/cmd/tradingagent/debate_timeout_provider.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/PatrickFanella/get-rich-quick/internal/llm"
+)
+
+type debateTimeoutFallbackProvider struct {
+	provider      llm.Provider
+	fallbackModel string
+	timeout       time.Duration
+	logger        *slog.Logger
+}
+
+func newDebateTimeoutFallbackProvider(provider llm.Provider, fallbackModel string, timeout time.Duration, logger *slog.Logger) llm.Provider {
+	if provider == nil {
+		return nil
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &debateTimeoutFallbackProvider{
+		provider:      provider,
+		fallbackModel: strings.TrimSpace(fallbackModel),
+		timeout:       timeout,
+		logger:        logger,
+	}
+}
+
+func (p *debateTimeoutFallbackProvider) Complete(ctx context.Context, request llm.CompletionRequest) (*llm.CompletionResponse, error) {
+	if p == nil || p.provider == nil || p.timeout <= 0 {
+		return p.provider.Complete(ctx, request)
+	}
+
+	firstCtx, cancel := context.WithTimeout(ctx, p.timeout)
+	resp, err := p.provider.Complete(firstCtx, request)
+	cancel()
+	if err == nil {
+		return resp, nil
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		return nil, err
+	}
+	originalModel := strings.TrimSpace(request.Model)
+	if p.fallbackModel == "" || p.fallbackModel == originalModel {
+		return nil, err
+	}
+
+	retryReq := request
+	retryReq.Model = p.fallbackModel
+	p.logger.Warn("debate: LLM call timed out, retrying with quick model",
+		slog.String("original_model", originalModel),
+		slog.String("fallback_model", p.fallbackModel),
+	)
+	retryCtx, retryCancel := context.WithTimeout(ctx, p.timeout)
+	defer retryCancel()
+	return p.provider.Complete(retryCtx, retryReq)
+}

--- a/cmd/tradingagent/debate_timeout_provider_test.go
+++ b/cmd/tradingagent/debate_timeout_provider_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/PatrickFanella/get-rich-quick/internal/agent"
+	"github.com/PatrickFanella/get-rich-quick/internal/llm"
+)
+
+type timeoutProviderCall struct {
+	model    string
+	deadline bool
+}
+
+type timeoutProviderStub struct {
+	calls []timeoutProviderCall
+	fn    func(int, llm.CompletionRequest) (*llm.CompletionResponse, error)
+}
+
+func (s *timeoutProviderStub) Complete(ctx context.Context, req llm.CompletionRequest) (*llm.CompletionResponse, error) {
+	_, hasDeadline := ctx.Deadline()
+	s.calls = append(s.calls, timeoutProviderCall{model: req.Model, deadline: hasDeadline})
+	if s.fn != nil {
+		return s.fn(len(s.calls), req)
+	}
+	return &llm.CompletionResponse{Content: "ok", Model: req.Model}, nil
+}
+
+func TestDebateTimeoutFallbackProvider_RetriesTimedOutCallWithQuickModel(t *testing.T) {
+	t.Parallel()
+
+	provider := &timeoutProviderStub{
+		fn: func(call int, req llm.CompletionRequest) (*llm.CompletionResponse, error) {
+			if call == 1 {
+				return nil, context.DeadlineExceeded
+			}
+			return &llm.CompletionResponse{Content: "ok", Model: req.Model}, nil
+		},
+	}
+	wrapped := newDebateTimeoutFallbackProvider(provider, "gpt-5-mini", 30*time.Second, slogDiscardLogger())
+
+	resp, err := wrapped.Complete(context.Background(), llm.CompletionRequest{Model: "gpt-5"})
+	if err != nil {
+		t.Fatalf("Complete() error = %v", err)
+	}
+	if resp == nil || resp.Model != "gpt-5-mini" {
+		t.Fatalf("response model = %v, want gpt-5-mini", resp)
+	}
+	if len(provider.calls) != 2 {
+		t.Fatalf("calls = %d, want 2", len(provider.calls))
+	}
+	if provider.calls[0].model != "gpt-5" || provider.calls[1].model != "gpt-5-mini" {
+		t.Fatalf("models = %+v, want [gpt-5 gpt-5-mini]", provider.calls)
+	}
+	if !provider.calls[0].deadline || !provider.calls[1].deadline {
+		t.Fatalf("expected deadlines on both calls, got %+v", provider.calls)
+	}
+}
+
+func TestDebateTimeoutFallbackProvider_DoesNotRetryNonTimeoutErrors(t *testing.T) {
+	t.Parallel()
+
+	provider := &timeoutProviderStub{fn: func(int, llm.CompletionRequest) (*llm.CompletionResponse, error) {
+		return nil, errors.New("boom")
+	}}
+	wrapped := newDebateTimeoutFallbackProvider(provider, "gpt-5-mini", 30*time.Second, slogDiscardLogger())
+
+	_, err := wrapped.Complete(context.Background(), llm.CompletionRequest{Model: "gpt-5"})
+	if err == nil {
+		t.Fatal("Complete() error = nil, want error")
+	}
+	if len(provider.calls) != 1 {
+		t.Fatalf("calls = %d, want 1", len(provider.calls))
+	}
+}
+
+func TestBuildRunnerDefinition_UsesEnvBoundedDebateTimeoutFallback(t *testing.T) {
+	t.Parallel()
+
+	resolved := agent.ResolvedConfig{
+		LLMConfig: agent.ResolvedLLMConfig{
+			QuickThinkModel: "gpt-5-mini",
+			DeepThinkModel:  "gpt-5",
+		},
+		PipelineConfig: agent.ResolvedPipelineConfig{
+			DebateTimeoutSeconds: 10,
+		},
+	}
+
+	if got := effectiveDebateCallTimeout(30*time.Second, resolved); got != 10*time.Second {
+		t.Fatalf("effectiveDebateCallTimeout() = %s, want %s", got, 10*time.Second)
+	}
+
+	definition, err := buildRunnerDefinition(captureProvider{}, "openai", resolved, 30*time.Second, nil, slogDiscardLogger())
+	if err != nil {
+		t.Fatalf("buildRunnerDefinition() error = %v", err)
+	}
+
+	if _, err := definition.Research.Debaters[0].Debate(context.Background(), agent.DebateInput{Ticker: "AAPL"}); err != nil {
+		t.Fatalf("debate call error = %v", err)
+	}
+	if _, err := definition.Risk.Judge.JudgeRisk(context.Background(), agent.RiskJudgeInput{Ticker: "AAPL", TradingPlan: agent.TradingPlan{Ticker: "AAPL"}}); err != nil {
+		t.Fatalf("risk judge call error = %v", err)
+	}
+}

--- a/cmd/tradingagent/llm_metrics_provider.go
+++ b/cmd/tradingagent/llm_metrics_provider.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/PatrickFanella/get-rich-quick/internal/llm"
+	"github.com/PatrickFanella/get-rich-quick/internal/metrics"
+)
+
+type llmMetricsProvider struct {
+	provider     llm.Provider
+	providerName string
+	agentRole    string
+	metrics      *metrics.Metrics
+}
+
+func newLLMMetricsProvider(provider llm.Provider, providerName, agentRole string, metrics *metrics.Metrics) llm.Provider {
+	if provider == nil || metrics == nil {
+		return provider
+	}
+	return &llmMetricsProvider{provider: provider, providerName: providerName, agentRole: agentRole, metrics: metrics}
+}
+
+func (p *llmMetricsProvider) Complete(ctx context.Context, request llm.CompletionRequest) (*llm.CompletionResponse, error) {
+	started := time.Now()
+	resp, err := p.provider.Complete(ctx, request)
+	model := strings.TrimSpace(request.Model)
+	if resp != nil && strings.TrimSpace(resp.Model) != "" {
+		model = strings.TrimSpace(resp.Model)
+	}
+	p.metrics.RecordLLMCall(p.providerName, model, p.agentRole)
+	p.metrics.ObserveLLMLatency(p.providerName, model, time.Since(started).Seconds())
+	if resp != nil {
+		p.metrics.RecordLLMTokens(resp.Usage.PromptTokens, resp.Usage.CompletionTokens)
+	}
+	return resp, err
+}

--- a/cmd/tradingagent/llm_metrics_provider_test.go
+++ b/cmd/tradingagent/llm_metrics_provider_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/PatrickFanella/get-rich-quick/internal/llm"
+	"github.com/PatrickFanella/get-rich-quick/internal/metrics"
+)
+
+type llmMetricsStubProvider struct{}
+
+func (llmMetricsStubProvider) Complete(context.Context, llm.CompletionRequest) (*llm.CompletionResponse, error) {
+	return &llm.CompletionResponse{
+		Content: "ok",
+		Model:   "gpt-5-mini",
+		Usage:   llm.CompletionUsage{PromptTokens: 11, CompletionTokens: 7},
+	}, nil
+}
+
+func TestLLMMetricsProvider_RecordsMetrics(t *testing.T) {
+	t.Parallel()
+
+	m := metrics.New()
+	wrapped := newLLMMetricsProvider(llmMetricsStubProvider{}, "openai", "bull_researcher", m)
+	if _, err := wrapped.Complete(context.Background(), llm.CompletionRequest{Model: "gpt-5"}); err != nil {
+		t.Fatalf("Complete() error = %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	m.Handler().ServeHTTP(rec, req)
+	body := rec.Body.String()
+	for _, want := range []string{"tradingagent_llm_calls_total", "provider=\"openai\"", "agent_role=\"bull_researcher\"", "tradingagent_llm_tokens_total", "tradingagent_llm_latency_seconds"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("metrics output missing %q", want)
+		}
+	}
+}

--- a/cmd/tradingagent/prod_strategy_runner.go
+++ b/cmd/tradingagent/prod_strategy_runner.go
@@ -27,6 +27,7 @@ import (
 	"github.com/PatrickFanella/get-rich-quick/internal/execution/paper"
 	polymarketexecution "github.com/PatrickFanella/get-rich-quick/internal/execution/polymarket"
 	"github.com/PatrickFanella/get-rich-quick/internal/llm"
+	"github.com/PatrickFanella/get-rich-quick/internal/metrics"
 	"github.com/PatrickFanella/get-rich-quick/internal/notification"
 	"github.com/PatrickFanella/get-rich-quick/internal/repository"
 	"github.com/PatrickFanella/get-rich-quick/internal/risk"
@@ -66,7 +67,9 @@ type realStrategyRunner struct {
 	tradeRepo           repository.TradeRepository
 	auditLogRepo        repository.AuditLogRepository
 	riskEngine          risk.RiskEngine
+	metrics             *metrics.Metrics
 	notificationManager *notification.Manager
+	runRegistry         *agent.RunContextRegistry
 	logger              *slog.Logger
 	localPaperMu        sync.Mutex
 	localPaperBroker    *paper.PaperBroker
@@ -86,7 +89,9 @@ func newRealStrategyRunner(
 	tradeRepo repository.TradeRepository,
 	auditLogRepo repository.AuditLogRepository,
 	riskEngine risk.RiskEngine,
+	appMetrics *metrics.Metrics,
 	notificationManager *notification.Manager,
+	runRegistry *agent.RunContextRegistry,
 	logger *slog.Logger,
 ) *realStrategyRunner {
 	if logger == nil {
@@ -106,7 +111,9 @@ func newRealStrategyRunner(
 		tradeRepo:           tradeRepo,
 		auditLogRepo:        auditLogRepo,
 		riskEngine:          riskEngine,
+		metrics:             appMetrics,
 		notificationManager: notificationManager,
+		runRegistry:         runRegistry,
 		logger:              logger,
 		localPaperBroker:    paper.NewPaperBroker(localPaperBuyingPower, 0, 0),
 	}
@@ -140,6 +147,10 @@ func (r *realStrategyRunner) RunStrategy(ctx context.Context, strategy domain.St
 	// Close the channel regardless of success/failure — the drainer exits via range.
 	if eventsCh != nil {
 		close(eventsCh)
+	}
+	defer r.refreshExecutionMetrics(context.Background())
+	if result != nil {
+		r.recordPipelineMetrics(result.Run)
 	}
 
 	if err != nil {
@@ -177,15 +188,11 @@ func (r *realStrategyRunner) RunStrategy(ctx context.Context, strategy domain.St
 
 	planTicker := result.State.TradingPlan.Ticker
 	if strategy.MarketType.Normalize() == domain.MarketTypePolymarket {
-		side := result.State.TradingPlan.Side
-		if side == "" {
-			return nil, fmt.Errorf("polymarket strategy %s: trader did not specify Side (YES/NO)", strategy.Name)
+		normalizedSide, err := normalizePolymarketStrategySide(result.State.TradingPlan.Side)
+		if err != nil {
+			return nil, fmt.Errorf("polymarket strategy %s: %w", strategy.Name, err)
 		}
-		switch strings.ToUpper(side) {
-		case "YES", "NO":
-		default:
-			return nil, fmt.Errorf("polymarket strategy %s: invalid Side %q (want YES or NO)", strategy.Name, side)
-		}
+		result.State.TradingPlan.Side = normalizedSide
 		entryPrice := result.State.TradingPlan.EntryPrice
 		if entryPrice > 0 && entryPrice > 1 {
 			return nil, fmt.Errorf("polymarket strategy %s: entry price %.4f outside valid range [0,1]", strategy.Name, entryPrice)
@@ -235,6 +242,27 @@ func (r *realStrategyRunner) RunStrategy(ctx context.Context, strategy domain.St
 	}, nil
 }
 
+func normalizePolymarketStrategySide(side string) (string, error) {
+	switch strings.ToUpper(strings.TrimSpace(side)) {
+	case "YES":
+		return "YES", nil
+	case "NO":
+		return "NO", nil
+	case "UP":
+		return "Up", nil
+	case "DOWN":
+		return "Down", nil
+	case "OVER":
+		return "Over", nil
+	case "UNDER":
+		return "Under", nil
+	case "":
+		return "", fmt.Errorf("trader did not specify Side (YES/NO/Up/Down/Over/Under)")
+	default:
+		return "", fmt.Errorf("invalid Side %q (want YES, NO, Up, Down, Over, or Under)", side)
+	}
+}
+
 func (r *realStrategyRunner) prepareStrategyRun(ctx context.Context, strategy domain.Strategy) (*agent.Runner, agent.PreparedRun, *agent.StrategyConfig, chan agent.PipelineEvent, error) {
 	strategyConfig, err := parseStrategyConfig(strategy.Config)
 	if err != nil {
@@ -247,7 +275,7 @@ func (r *realStrategyRunner) prepareStrategyRun(ctx context.Context, strategy do
 		return nil, agent.PreparedRun{}, nil, nil, fmt.Errorf("build llm provider for strategy %s: %w", strategy.Name, err)
 	}
 
-	definition, err := buildRunnerDefinition(provider, resolved.LLMConfig.Provider, resolved, r.logger)
+	definition, err := buildRunnerDefinition(provider, resolved.LLMConfig.Provider, resolved, r.cfg.LLM.Timeout, r.metrics, r.logger)
 	if err != nil {
 		return nil, agent.PreparedRun{}, nil, nil, err
 	}
@@ -257,9 +285,10 @@ func (r *realStrategyRunner) prepareStrategyRun(ctx context.Context, strategy do
 		eventsCh = make(chan agent.PipelineEvent, 64)
 	}
 	runner := agent.NewRunner(definition, agent.Dependencies{
-		Persister: agent.NewRepoPersister(r.runRepo, r.snapshotRepo, r.decisionRepo, r.eventRepo, r.logger),
-		Events:    eventsCh,
-		Logger:    r.logger,
+		Persister:   agent.NewRepoPersister(r.runRepo, r.snapshotRepo, r.decisionRepo, r.eventRepo, r.logger),
+		Events:      eventsCh,
+		Logger:      r.logger,
+		RunRegistry: r.runRegistry,
 	})
 
 	prepared, err := runner.Prepare(strategy, r.globals)
@@ -348,33 +377,49 @@ func (r *realStrategyRunner) loadInitialState(ctx context.Context, strategy doma
 	return seed, nil
 }
 
-func buildRunnerDefinition(provider llm.Provider, providerName string, resolved agent.ResolvedConfig, logger *slog.Logger) (agent.Definition, error) {
-	analysisAgents, err := buildAnalysisAgents(provider, providerName, resolved, logger)
+func buildRunnerDefinition(provider llm.Provider, providerName string, resolved agent.ResolvedConfig, llmTimeout time.Duration, appMetrics *metrics.Metrics, logger *slog.Logger) (agent.Definition, error) {
+	analysisAgents, err := buildAnalysisAgents(provider, providerName, resolved, appMetrics, logger)
 	if err != nil {
 		return agent.Definition{}, err
 	}
 
 	deepModel := strings.TrimSpace(resolved.LLMConfig.DeepThinkModel)
+	quickModel := strings.TrimSpace(resolved.LLMConfig.QuickThinkModel)
+	debateProvider := newDebateTimeoutFallbackProvider(provider, quickModel, effectiveDebateCallTimeout(llmTimeout, resolved), logger)
 
 	return agent.Definition{
 		Analysis: analysisAgents,
 		Research: agent.ResearchDebateStage{
 			Debaters: []agent.DebateAgent{
-				agentdebate.NewBullResearcherWithPrompt(provider, providerName, deepModel, promptOverride(resolved.PromptOverrides, agent.AgentRoleBullResearcher, agentdebate.BullResearcherSystemPrompt), logger),
-				agentdebate.NewBearResearcherWithPrompt(provider, providerName, deepModel, promptOverride(resolved.PromptOverrides, agent.AgentRoleBearResearcher, agentdebate.BearResearcherSystemPrompt), logger),
+				agentdebate.NewBullResearcherWithPrompt(newLLMMetricsProvider(debateProvider, providerName, agent.AgentRoleBullResearcher.String(), appMetrics), providerName, deepModel, promptOverride(resolved.PromptOverrides, agent.AgentRoleBullResearcher, agentdebate.BullResearcherSystemPrompt), logger),
+				agentdebate.NewBearResearcherWithPrompt(newLLMMetricsProvider(debateProvider, providerName, agent.AgentRoleBearResearcher.String(), appMetrics), providerName, deepModel, promptOverride(resolved.PromptOverrides, agent.AgentRoleBearResearcher, agentdebate.BearResearcherSystemPrompt), logger),
 			},
-			Judge: agentdebate.NewResearchManagerWithPrompt(provider, providerName, deepModel, promptOverride(resolved.PromptOverrides, agent.AgentRoleInvestJudge, agentdebate.ResearchManagerSystemPrompt), logger),
+			Judge: agentdebate.NewResearchManagerWithPrompt(newLLMMetricsProvider(debateProvider, providerName, agent.AgentRoleInvestJudge.String(), appMetrics), providerName, deepModel, promptOverride(resolved.PromptOverrides, agent.AgentRoleInvestJudge, agentdebate.ResearchManagerSystemPrompt), logger),
 		},
-		Trader: agenttrader.NewTraderWithPrompt(provider, providerName, deepModel, promptOverride(resolved.PromptOverrides, agent.AgentRoleTrader, agenttrader.TraderSystemPrompt), logger),
+		Trader: agenttrader.NewTraderWithPrompt(newLLMMetricsProvider(provider, providerName, agent.AgentRoleTrader.String(), appMetrics), providerName, deepModel, promptOverride(resolved.PromptOverrides, agent.AgentRoleTrader, agenttrader.TraderSystemPrompt), logger),
 		Risk: agent.RiskDebateStage{
 			Debaters: []agent.DebateAgent{
-				agentrisk.NewAggressiveRiskWithPrompt(provider, providerName, deepModel, promptOverride(resolved.PromptOverrides, agent.AgentRoleAggressiveAnalyst, agentrisk.AggressiveRiskSystemPrompt), logger),
-				agentrisk.NewConservativeRiskWithPrompt(provider, providerName, deepModel, promptOverride(resolved.PromptOverrides, agent.AgentRoleConservativeAnalyst, agentrisk.ConservativeRiskSystemPrompt), logger),
-				agentrisk.NewNeutralRiskWithPrompt(provider, providerName, deepModel, promptOverride(resolved.PromptOverrides, agent.AgentRoleNeutralAnalyst, agentrisk.NeutralRiskSystemPrompt), logger),
+				agentrisk.NewAggressiveRiskWithPrompt(newLLMMetricsProvider(debateProvider, providerName, agent.AgentRoleAggressiveAnalyst.String(), appMetrics), providerName, deepModel, promptOverride(resolved.PromptOverrides, agent.AgentRoleAggressiveAnalyst, agentrisk.AggressiveRiskSystemPrompt), logger),
+				agentrisk.NewConservativeRiskWithPrompt(newLLMMetricsProvider(debateProvider, providerName, agent.AgentRoleConservativeAnalyst.String(), appMetrics), providerName, deepModel, promptOverride(resolved.PromptOverrides, agent.AgentRoleConservativeAnalyst, agentrisk.ConservativeRiskSystemPrompt), logger),
+				agentrisk.NewNeutralRiskWithPrompt(newLLMMetricsProvider(debateProvider, providerName, agent.AgentRoleNeutralAnalyst.String(), appMetrics), providerName, deepModel, promptOverride(resolved.PromptOverrides, agent.AgentRoleNeutralAnalyst, agentrisk.NeutralRiskSystemPrompt), logger),
 			},
-			Judge: agentrisk.NewRiskManagerWithPrompt(provider, providerName, deepModel, promptOverride(resolved.PromptOverrides, agent.AgentRoleRiskManager, agentrisk.RiskManagerSystemPrompt), logger),
+			Judge: agentrisk.NewRiskManagerWithPrompt(newLLMMetricsProvider(debateProvider, providerName, agent.AgentRoleRiskManager.String(), appMetrics), providerName, deepModel, promptOverride(resolved.PromptOverrides, agent.AgentRoleRiskManager, agentrisk.RiskManagerSystemPrompt), logger),
 		},
 	}, nil
+}
+
+func effectiveDebateCallTimeout(llmTimeout time.Duration, resolved agent.ResolvedConfig) time.Duration {
+	var timeout time.Duration
+	if llmTimeout > 0 {
+		timeout = llmTimeout
+	}
+	if resolved.PipelineConfig.DebateTimeoutSeconds > 0 {
+		debateTimeout := time.Duration(resolved.PipelineConfig.DebateTimeoutSeconds) * time.Second
+		if timeout <= 0 || debateTimeout < timeout {
+			timeout = debateTimeout
+		}
+	}
+	return timeout
 }
 
 func promptOverride(overrides map[agent.AgentRole]string, role agent.AgentRole, fallback string) string {
@@ -385,7 +430,7 @@ func promptOverride(overrides map[agent.AgentRole]string, role agent.AgentRole, 
 	return prompt
 }
 
-func buildAnalysisAgents(provider llm.Provider, providerName string, resolved agent.ResolvedConfig, logger *slog.Logger) ([]agent.AnalysisAgent, error) {
+func buildAnalysisAgents(provider llm.Provider, providerName string, resolved agent.ResolvedConfig, appMetrics *metrics.Metrics, logger *slog.Logger) ([]agent.AnalysisAgent, error) {
 	roles, err := selectedAnalysisRoles(resolved.AnalystSelection)
 	if err != nil {
 		return nil, err
@@ -394,7 +439,7 @@ func buildAnalysisAgents(provider llm.Provider, providerName string, resolved ag
 	model := strings.TrimSpace(resolved.LLMConfig.QuickThinkModel)
 	agents := make([]agent.AnalysisAgent, 0, len(roles))
 	for _, role := range roles {
-		agentImpl, err := newAnalysisAgent(provider, providerName, model, role, resolved.PromptOverrides[role], logger)
+		agentImpl, err := newAnalysisAgent(provider, providerName, model, role, resolved.PromptOverrides[role], appMetrics, logger)
 		if err != nil {
 			return nil, err
 		}
@@ -444,10 +489,12 @@ func isAnalysisRole(role agent.AgentRole) bool {
 	}
 }
 
-func newAnalysisAgent(provider llm.Provider, providerName, model string, role agent.AgentRole, promptOverride string, logger *slog.Logger) (agent.AnalysisAgent, error) {
+func newAnalysisAgent(provider llm.Provider, providerName, model string, role agent.AgentRole, promptOverride string, appMetrics *metrics.Metrics, logger *slog.Logger) (agent.AnalysisAgent, error) {
 	if logger == nil {
 		logger = slog.Default()
 	}
+
+	provider = newLLMMetricsProvider(provider, providerName, role.String(), appMetrics)
 
 	prompt := strings.TrimSpace(promptOverride)
 	switch role {
@@ -605,7 +652,34 @@ func (r *realStrategyRunner) newOrderManager(strategy domain.Strategy, resolved 
 			FractionPct: resolved.RiskConfig.PositionSizePct / 100.0,
 		},
 		r.logger,
-	), nil
+	).WithMetrics(r.metrics), nil
+}
+
+func (r *realStrategyRunner) recordPipelineMetrics(run domain.PipelineRun) {
+	if r == nil || r.metrics == nil {
+		return
+	}
+	signal := run.Signal.String()
+	if signal == "" {
+		signal = string(domain.PipelineSignalHold)
+	}
+	r.metrics.RecordPipelineRun(run.Ticker, signal, run.Status.String())
+	if run.CompletedAt != nil {
+		r.metrics.ObservePipelineDuration(run.Ticker, run.CompletedAt.Sub(run.StartedAt).Seconds())
+	}
+}
+
+func (r *realStrategyRunner) refreshExecutionMetrics(ctx context.Context) {
+	if r == nil || r.metrics == nil {
+		return
+	}
+	if count, err := r.positionRepo.CountOpen(ctx, repository.PositionFilter{}); err == nil {
+		r.metrics.SetPositionsOpen(float64(count))
+	}
+	if status, err := r.riskEngine.GetStatus(ctx); err == nil {
+		r.metrics.SetCircuitBreakerState(status.CircuitBreaker.State == risk.CircuitBreakerPhaseTripped)
+		r.metrics.SetKillSwitchActive(status.KillSwitch.Active)
+	}
 }
 
 func (r *realStrategyRunner) newBrokerForStrategy(strategy domain.Strategy) (execution.Broker, string, error) {

--- a/cmd/tradingagent/prod_strategy_runner_test.go
+++ b/cmd/tradingagent/prod_strategy_runner_test.go
@@ -1,0 +1,44 @@
+package main
+
+import "testing"
+
+func TestNormalizePolymarketStrategySide(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{name: "yes", input: "yes", want: "YES"},
+		{name: "no", input: "NO", want: "NO"},
+		{name: "up", input: "up", want: "Up"},
+		{name: "down", input: "Down", want: "Down"},
+		{name: "over", input: "OVER", want: "Over"},
+		{name: "under", input: "under", want: "Under"},
+		{name: "blank", input: "", wantErr: true},
+		{name: "invalid", input: "sideways", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := normalizePolymarketStrategySide(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("normalizePolymarketStrategySide(%q) error = nil, want error", tc.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("normalizePolymarketStrategySide(%q) error = %v", tc.input, err)
+			}
+			if got != tc.want {
+				t.Fatalf("normalizePolymarketStrategySide(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/tradingagent/runtime.go
+++ b/cmd/tradingagent/runtime.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 	"strings"
 	"time"
 
@@ -75,6 +76,7 @@ func newAPIServer(ctx context.Context, cfg config.Config, logger *slog.Logger) (
 	optionsScanRepo := pgrepo.NewOptionsScanRepo(db.Pool)
 	newsFeedRepo := pgrepo.NewNewsFeedRepo(db.Pool)
 	polymarketAccountRepo := pgrepo.NewPolymarketAccountRepo(db.Pool)
+	runRegistry := agent.NewRunContextRegistry()
 
 	riskEngine := risk.NewRiskEngine(
 		risk.PositionLimits{
@@ -203,7 +205,9 @@ func newAPIServer(ctx context.Context, cfg config.Config, logger *slog.Logger) (
 			tradeRepo,
 			auditLogRepo,
 			riskEngine,
+			appMetrics,
 			notificationManager,
+			runRegistry,
 			logger,
 		)
 		deps.Runner = strategyRunner
@@ -372,11 +376,45 @@ func newAPIServer(ctx context.Context, cfg config.Config, logger *slog.Logger) (
 		schedLifecycle = sched
 	}
 
+	staleRunTTL := loadStaleRunTTL(logger)
+	var staleRunReconcilerCancel context.CancelFunc = func() {}
+	if staleRunTTL > 0 {
+		reconciler := agent.NewStaleRunReconciler(
+			runRepo,
+			auditLogRepo,
+			runRegistry,
+			appMetrics,
+			logger,
+			agent.StaleRunReconcilerConfig{TTL: staleRunTTL, Interval: time.Minute},
+		)
+		var reconcileCtx context.Context
+		reconcileCtx, staleRunReconcilerCancel = context.WithCancel(context.Background())
+		reconciler.Start(reconcileCtx)
+		logger.Info("stale run reconciler started", slog.Duration("ttl", staleRunTTL), slog.Duration("interval", time.Minute))
+	}
+
 	return server, schedLifecycle, func() {
+		staleRunReconcilerCancel()
 		signalShutdown()
 		closeRedis()
 		db.Close()
 	}, nil
+}
+
+func loadStaleRunTTL(logger *slog.Logger) time.Duration {
+	const fallback = 30 * time.Minute
+	raw := strings.TrimSpace(os.Getenv("STALE_RUN_TTL"))
+	if raw == "" {
+		return fallback
+	}
+	ttl, err := time.ParseDuration(raw)
+	if err != nil || ttl <= 0 {
+		if logger != nil {
+			logger.Warn("invalid STALE_RUN_TTL, using default", slog.String("value", raw), slog.Duration("default", fallback))
+		}
+		return fallback
+	}
+	return ttl
 }
 
 // throttleLLM wraps a provider with a global concurrency limiter so that

--- a/cmd/tradingagent/runtime_stale_run_test.go
+++ b/cmd/tradingagent/runtime_stale_run_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func TestLoadStaleRunTTL(t *testing.T) {
+	t.Parallel()
+
+	old := os.Getenv("STALE_RUN_TTL")
+	defer func() {
+		if old == "" {
+			_ = os.Unsetenv("STALE_RUN_TTL")
+		} else {
+			_ = os.Setenv("STALE_RUN_TTL", old)
+		}
+	}()
+
+	tests := []struct {
+		name  string
+		value string
+		want  time.Duration
+	}{
+		{name: "default when unset", value: "", want: 30 * time.Minute},
+		{name: "custom duration", value: "45m", want: 45 * time.Minute},
+		{name: "invalid falls back", value: "oops", want: 30 * time.Minute},
+		{name: "non-positive falls back", value: "0s", want: 30 * time.Minute},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.value == "" {
+				_ = os.Unsetenv("STALE_RUN_TTL")
+			} else {
+				_ = os.Setenv("STALE_RUN_TTL", tc.value)
+			}
+			if got := loadStaleRunTTL(slogDiscardLogger()); got != tc.want {
+				t.Fatalf("loadStaleRunTTL() = %s, want %s", got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/tradingagent/runtime_test.go
+++ b/cmd/tradingagent/runtime_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/PatrickFanella/get-rich-quick/internal/domain"
 	"github.com/PatrickFanella/get-rich-quick/internal/execution/paper"
 	"github.com/PatrickFanella/get-rich-quick/internal/llm"
+	"github.com/PatrickFanella/get-rich-quick/internal/metrics"
 	"github.com/PatrickFanella/get-rich-quick/internal/notification"
 	"github.com/PatrickFanella/get-rich-quick/internal/repository"
 	"github.com/PatrickFanella/get-rich-quick/internal/risk"
@@ -293,6 +294,30 @@ func (stubPositionRepo) CountOpen(context.Context, repository.PositionFilter) (i
 	return 0, nil
 }
 
+type metricPositionRepo struct{ count int }
+
+func (m metricPositionRepo) Create(context.Context, *domain.Position) error { return nil }
+func (m metricPositionRepo) Get(context.Context, uuid.UUID) (*domain.Position, error) {
+	return nil, repository.ErrNotFound
+}
+func (m metricPositionRepo) List(context.Context, repository.PositionFilter, int, int) ([]domain.Position, error) {
+	return nil, nil
+}
+func (m metricPositionRepo) Update(context.Context, *domain.Position) error { return nil }
+func (m metricPositionRepo) Delete(context.Context, uuid.UUID) error        { return nil }
+func (m metricPositionRepo) GetOpen(context.Context, repository.PositionFilter, int, int) ([]domain.Position, error) {
+	return nil, nil
+}
+func (m metricPositionRepo) GetByStrategy(context.Context, uuid.UUID, repository.PositionFilter, int, int) ([]domain.Position, error) {
+	return nil, nil
+}
+func (m metricPositionRepo) Count(context.Context, repository.PositionFilter) (int, error) {
+	return m.count, nil
+}
+func (m metricPositionRepo) CountOpen(context.Context, repository.PositionFilter) (int, error) {
+	return m.count, nil
+}
+
 func TestSelectedAnalysisRoles_RejectsNonAnalysisRoles(t *testing.T) {
 	t.Parallel()
 
@@ -313,7 +338,7 @@ func TestBuildAnalysisAgents_RespectsAnalystSelection(t *testing.T) {
 		},
 	}
 
-	agents, err := buildAnalysisAgents(nil, "openai", resolved, nil)
+	agents, err := buildAnalysisAgents(nil, "openai", resolved, nil, nil)
 	if err != nil {
 		t.Fatalf("buildAnalysisAgents() error = %v", err)
 	}
@@ -439,6 +464,40 @@ func TestRealStrategyRunnerNewOrderManager_WiresRiskPortfolioSnapshot(t *testing
 	}
 }
 
+func TestRealStrategyRunnerExecutionMetricsHelpers(t *testing.T) {
+	t.Parallel()
+
+	positionRepo := metricPositionRepo{count: 2}
+	engine := risk.NewRiskEngine(risk.DefaultPositionLimits(), risk.DefaultCircuitBreakerConfig(), positionRepo, slogDiscardLogger())
+	if err := engine.ActivateKillSwitch(context.Background(), "test"); err != nil {
+		t.Fatalf("ActivateKillSwitch() error = %v", err)
+	}
+	if err := engine.TripCircuitBreaker(context.Background(), "trip"); err != nil {
+		t.Fatalf("TripCircuitBreaker() error = %v", err)
+	}
+	m := metrics.New()
+	runner := &realStrategyRunner{positionRepo: positionRepo, riskEngine: engine, metrics: m}
+	completedAt := time.Date(2026, 4, 11, 12, 30, 0, 0, time.UTC)
+	runner.recordPipelineMetrics(domain.PipelineRun{
+		Ticker:      "AAPL",
+		Signal:      domain.PipelineSignalBuy,
+		Status:      domain.PipelineStatusCompleted,
+		StartedAt:   completedAt.Add(-2 * time.Minute),
+		CompletedAt: &completedAt,
+	})
+	runner.refreshExecutionMetrics(context.Background())
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	m.Handler().ServeHTTP(rec, req)
+	body := rec.Body.String()
+	for _, want := range []string{"tradingagent_pipeline_runs_total", "ticker=\"AAPL\"", "tradingagent_pipeline_duration_seconds", "tradingagent_positions_open 2", "tradingagent_circuit_breaker_state 1", "tradingagent_kill_switch_active 1"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("metrics output missing %q", want)
+		}
+	}
+}
+
 func TestBuildRunnerDefinition_AppliesPromptOverridesBeyondAnalysis(t *testing.T) {
 	t.Parallel()
 
@@ -459,7 +518,7 @@ func TestBuildRunnerDefinition_AppliesPromptOverridesBeyondAnalysis(t *testing.T
 		},
 	}
 
-	definition, err := buildRunnerDefinition(captureProvider{}, "openai", resolved, slogDiscardLogger())
+	definition, err := buildRunnerDefinition(captureProvider{}, "openai", resolved, 30*time.Second, nil, slogDiscardLogger())
 	if err != nil {
 		t.Fatalf("buildRunnerDefinition() error = %v", err)
 	}

--- a/docs/implementation-board.md
+++ b/docs/implementation-board.md
@@ -7,20 +7,15 @@ tags: [kanban, tracking]
 
 ## Backlog
 
-- [ ] Data provider chain with cache integration
-- [ ] Alpaca paper trading integration
 - [ ] 60-day validation plan
-- [ ] Backtesting engine core
 
 ## In Progress
 
-- [ ] Pipeline orchestration engine (DAG executor)
-- [ ] Alpaca broker adapter
+- [ ] Repo-health cleanup and merge-conflict resolution pass
 
 ## Blocked
 
-- [ ] Research debate orchestration (needs bull/bear agents)
-- [ ] Risk debate orchestration (needs risk analyst agents)
+- [ ] Public backtest surface in the main API/UI
 
 ## Done
 
@@ -41,6 +36,13 @@ tags: [kanban, tracking]
 - [ ] Configuration system
 - [ ] Structured logging
 - [ ] Database schema + migrations
+- [ ] Data provider chain with cache integration
+- [ ] Alpaca paper trading integration
+- [ ] Alpaca broker adapter
+- [ ] Pipeline orchestration engine
+- [ ] Research debate orchestration
+- [ ] Risk debate orchestration
+- [ ] Backtesting engine core
 
 %% kanban:settings
 

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -50,7 +50,7 @@ the built-in cron engine.
 ### ~~Polymarket support is incomplete~~ ✓ More complete than documented
 
 The production strategy runner now handles `market_type: polymarket` strategies through the retail Polymarket US API:
-- Preserves trader-selected YES/NO side through execution and maps it to retail order intents
+- Preserves trader-selected outcome side through execution and maps YES/NO plus Up/Down/Over/Under intents for supported retail markets
 - Routes live orders through `polymarketexecution.Broker` when `POLYMARKET_KEY_ID` and `POLYMARKET_SECRET_KEY` are set
 - Falls back to local paper broker when `is_paper: true` (Polymarket has no native paper mode)
 - Enforces per-market exposure, liquidity, spread, and resolution-timeline risk limits
@@ -88,6 +88,14 @@ are unchanged and always re-evaluated at runtime.
 `runtimePipelineTimeout` now derives a finite wall-clock budget from the per-phase
 timeout settings: `(analysts × analysis_timeout) + (2 × rounds × debate_timeout) + overhead`.
 Falls back to 30 minutes when any constituent is unconfigured.
+
+### ~~Stale runs remained stuck at `running` forever~~ ✓ Fixed
+
+The runtime now starts a stale-run reconciler that sweeps `pipeline_runs` for
+`status='running'` rows older than `STALE_RUN_TTL` (default `30m`), marks them
+`failed`, writes a `pipeline_run.stale_reconciled` audit entry, increments
+`tradingagent_stale_runs_reconciled_total`, and best-effort cancels any still-registered
+in-process run context.
 
 ### ~~Pagination `total` field never populated~~ ✓ Fixed (except memories, conversation messages)
 

--- a/docs/phase-7-execution-paths.md
+++ b/docs/phase-7-execution-paths.md
@@ -7,6 +7,8 @@ tags: [tracking, phase-7, paper-trading, production, production-ready]
 
 # Phase 7: Execution Paths
 
+> Archived planning snapshot. Many items below are now implemented or reprioritized. Prefer `docs/README.md`, `docs/reference/*`, and the live GitHub issue tracker for current state.
+
 > 95 sub-issues across 9 tracks (21 epics). **34 ready now**, 61 blocked by dependencies.
 > Updated: 2026-03-30
 > Tracking issue: [#391](https://github.com/PatrickFanella/get-rich-quick/issues/391)

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -292,6 +292,6 @@ type RiskEngine interface {
 
 - The production runner supports OpenAI, Anthropic, Google, OpenRouter, xAI, and Ollama.
 - `openrouter` and `xai` are handled through OpenAI-compatible transport wiring in the runtime.
-- The settings service used by the API/UI is currently memory-backed rather than persistent.
+- The settings service used by the API/UI persists through the `app_settings` table when the settings persister is wired; fallback in-memory behavior is only for degraded/local scenarios.
 - The repository includes backtest support, but the main API server does not yet expose a full public backtest surface.
 - Some files in the repo currently contain merge-conflict markers; treat repo-health as a real architecture constraint until they are resolved.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -15,7 +15,7 @@ All durable server configuration currently starts in the environment.
 - `internal/config.Load()` reads environment variables
 - `.env` is auto-loaded only when `APP_ENV=development`
 - validation runs after loading
-- the API settings surface is separate and currently memory-backed
+- the API settings surface is separate and persists via the `app_settings` table when a database-backed persister is available
 
 ## Major configuration groups
 
@@ -40,6 +40,7 @@ All durable server configuration currently starts in the environment.
 - `LLM_DEEP_THINK_MODEL`
 - `LLM_QUICK_THINK_MODEL`
 - `LLM_TIMEOUT`
+- `STALE_RUN_TTL` - duration string for stale-run reconciliation (default `30m`)
 - provider-specific keys and base URLs
 
 ### Data providers

--- a/docs/reference/llm.md
+++ b/docs/reference/llm.md
@@ -124,4 +124,4 @@ Trade-off:
 
 ## UI/settings caveat
 
-The settings page lets you edit provider settings, but those edits live in the memory-backed settings service. They do not persist across restart.
+The settings page lets you edit provider settings. In the API server those edits persist via the `app_settings` table when the settings persister is configured; local/dev workflows without a writable database may still behave ephemerally.

--- a/internal/agent/run_context_registry.go
+++ b/internal/agent/run_context_registry.go
@@ -1,0 +1,56 @@
+package agent
+
+import (
+	"context"
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+// RunContextRegistry tracks active run cancellation functions for best-effort cleanup.
+type RunContextRegistry struct {
+	mu      sync.Mutex
+	cancels map[uuid.UUID]context.CancelFunc
+}
+
+// NewRunContextRegistry creates an empty active-run registry.
+func NewRunContextRegistry() *RunContextRegistry {
+	return &RunContextRegistry{cancels: make(map[uuid.UUID]context.CancelFunc)}
+}
+
+// Register stores the cancel func for a running pipeline.
+func (r *RunContextRegistry) Register(runID uuid.UUID, cancel context.CancelFunc) {
+	if r == nil || cancel == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.cancels[runID] = cancel
+}
+
+// Deregister removes a pipeline from the registry after it exits.
+func (r *RunContextRegistry) Deregister(runID uuid.UUID) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.cancels, runID)
+}
+
+// Cancel invokes the cancel func for an active pipeline if one is registered.
+func (r *RunContextRegistry) Cancel(runID uuid.UUID) bool {
+	if r == nil {
+		return false
+	}
+	r.mu.Lock()
+	cancel, ok := r.cancels[runID]
+	if ok {
+		delete(r.cancels, runID)
+	}
+	r.mu.Unlock()
+	if ok {
+		cancel()
+	}
+	return ok
+}

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -56,10 +56,11 @@ type RunPersister = DecisionPersister
 
 // Dependencies holds runner infrastructure dependencies.
 type Dependencies struct {
-	Persister RunPersister
-	Events    chan<- PipelineEvent
-	Logger    *slog.Logger
-	Clock     func() time.Time
+	Persister   RunPersister
+	Events      chan<- PipelineEvent
+	Logger      *slog.Logger
+	Clock       func() time.Time
+	RunRegistry *RunContextRegistry
 }
 
 // Definition describes the concrete participants for each stage.
@@ -143,13 +144,14 @@ type RunResult struct {
 
 // Runner owns immutable run preparation and execution.
 type Runner struct {
-	def       Definition
-	persister RunPersister
-	events    chan<- PipelineEvent
-	logger    *slog.Logger
-	nowMu     sync.RWMutex
-	now       func() time.Time
-	helper    PhaseHelper
+	def         Definition
+	persister   RunPersister
+	events      chan<- PipelineEvent
+	logger      *slog.Logger
+	nowMu       sync.RWMutex
+	now         func() time.Time
+	helper      PhaseHelper
+	runRegistry *RunContextRegistry
 }
 
 // NewRunner constructs a runner with the supplied participants and dependencies.
@@ -163,11 +165,12 @@ func NewRunner(def Definition, deps Dependencies) *Runner {
 		clock = time.Now
 	}
 	r := &Runner{
-		def:       def,
-		persister: deps.Persister,
-		events:    deps.Events,
-		logger:    logger,
-		now:       clock,
+		def:         def,
+		persister:   deps.Persister,
+		events:      deps.Events,
+		logger:      logger,
+		now:         clock,
+		runRegistry: deps.RunRegistry,
 	}
 	r.helper = newPhaseHelper(deps.Persister, deps.Events, logger, r.currentTime)
 	return r
@@ -231,11 +234,13 @@ func (r *Runner) Run(ctx context.Context, prepared PreparedRun) (*RunResult, err
 		return nil, fmt.Errorf("agent/runner: persister is required")
 	}
 
+	var cancel context.CancelFunc
 	if prepared.Runtime.PipelineTimeout > 0 {
-		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, prepared.Runtime.PipelineTimeout)
-		defer cancel()
+	} else {
+		ctx, cancel = context.WithCancel(ctx)
 	}
+	defer cancel()
 
 	cacheStatsCollector := llm.NewCacheStatsCollector()
 	ctx = llm.WithCacheStatsCollector(ctx, cacheStatsCollector)
@@ -252,6 +257,10 @@ func (r *Runner) Run(ctx context.Context, prepared PreparedRun) (*RunResult, err
 	}
 	if err := r.persister.RecordRunStart(ctx, &run); err != nil {
 		return nil, err
+	}
+	if r.runRegistry != nil {
+		r.runRegistry.Register(run.ID, cancel)
+		defer r.runRegistry.Deregister(run.ID)
 	}
 
 	state := &PipelineState{

--- a/internal/agent/stale_run_reconciler.go
+++ b/internal/agent/stale_run_reconciler.go
@@ -1,0 +1,167 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"time"
+
+	"github.com/PatrickFanella/get-rich-quick/internal/domain"
+	"github.com/PatrickFanella/get-rich-quick/internal/repository"
+	"github.com/google/uuid"
+)
+
+const staleRunUpdateTimeout = 10 * time.Second
+
+// StaleRunMetrics captures the single stale-run metric emitted by the reconciler.
+type StaleRunMetrics interface {
+	RecordStaleRunReconciled()
+}
+
+// StaleRunReconcilerConfig defines the stale-run watchdog cadence and clock source.
+type StaleRunReconcilerConfig struct {
+	TTL      time.Duration
+	Interval time.Duration
+	Clock    func() time.Time
+}
+
+// StaleRunReconciler marks abandoned running pipeline runs as failed.
+type StaleRunReconciler struct {
+	runs     repository.PipelineRunRepository
+	auditLog repository.AuditLogRepository
+	registry *RunContextRegistry
+	metrics  StaleRunMetrics
+	logger   *slog.Logger
+	ttl      time.Duration
+	interval time.Duration
+	clock    func() time.Time
+}
+
+// NewStaleRunReconciler constructs a stale-run watchdog.
+func NewStaleRunReconciler(
+	runs repository.PipelineRunRepository,
+	auditLog repository.AuditLogRepository,
+	registry *RunContextRegistry,
+	metrics StaleRunMetrics,
+	logger *slog.Logger,
+	cfg StaleRunReconcilerConfig,
+) *StaleRunReconciler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	clock := cfg.Clock
+	if clock == nil {
+		clock = time.Now
+	}
+	interval := cfg.Interval
+	if interval <= 0 {
+		interval = time.Minute
+	}
+	return &StaleRunReconciler{
+		runs:     runs,
+		auditLog: auditLog,
+		registry: registry,
+		metrics:  metrics,
+		logger:   logger,
+		ttl:      cfg.TTL,
+		interval: interval,
+		clock:    clock,
+	}
+}
+
+// Start begins the periodic stale-run sweep until ctx is cancelled.
+func (r *StaleRunReconciler) Start(ctx context.Context) {
+	if r == nil || r.runs == nil || r.ttl <= 0 {
+		return
+	}
+	go func() {
+		ticker := time.NewTicker(r.interval)
+		defer ticker.Stop()
+		for {
+			if _, err := r.Reconcile(ctx); err != nil {
+				r.logger.Warn("stale run reconciler sweep failed", slog.Any("error", err))
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+			}
+		}
+	}()
+}
+
+// Reconcile performs one stale-run sweep and returns the number of repaired runs.
+func (r *StaleRunReconciler) Reconcile(ctx context.Context) (int, error) {
+	if r == nil || r.runs == nil || r.ttl <= 0 {
+		return 0, nil
+	}
+	now := r.clock().UTC()
+	cutoff := now.Add(-r.ttl)
+	runs, err := r.runs.List(ctx, repository.PipelineRunFilter{
+		Status:        domain.PipelineStatusRunning,
+		StartedBefore: &cutoff,
+	}, 500, 0)
+	if err != nil {
+		return 0, err
+	}
+
+	reconciled := 0
+	for _, run := range runs {
+		completedAt := now
+		updateCtx, cancel := context.WithTimeout(context.Background(), staleRunUpdateTimeout)
+		err := r.runs.UpdateStatus(updateCtx, run.ID, run.TradeDate, repository.PipelineRunStatusUpdate{
+			Status:       domain.PipelineStatusFailed,
+			CompletedAt:  &completedAt,
+			ErrorMessage: "stale run: exceeded TTL",
+		})
+		cancel()
+		if err != nil {
+			r.logger.Warn("stale run reconciler failed to update run status",
+				slog.String("run_id", run.ID.String()),
+				slog.Any("error", err),
+			)
+			continue
+		}
+
+		cancelled := r.registry != nil && r.registry.Cancel(run.ID)
+		r.writeAuditLog(run, now, cancelled)
+		if r.metrics != nil {
+			r.metrics.RecordStaleRunReconciled()
+		}
+		reconciled++
+	}
+	return reconciled, nil
+}
+
+func (r *StaleRunReconciler) writeAuditLog(run domain.PipelineRun, now time.Time, cancelled bool) {
+	if r.auditLog == nil {
+		return
+	}
+	raw, err := json.Marshal(map[string]any{
+		"reason":            "stale run: exceeded TTL",
+		"started_at":        run.StartedAt.UTC(),
+		"reconciled_at":     now,
+		"stale_for":         now.Sub(run.StartedAt).String(),
+		"context_cancelled": cancelled,
+	})
+	if err != nil {
+		r.logger.Warn("stale run reconciler failed to marshal audit details", slog.Any("error", err))
+		return
+	}
+	entityID := run.ID
+	entry := &domain.AuditLogEntry{
+		ID:         uuid.New(),
+		EventType:  "pipeline_run.stale_reconciled",
+		EntityType: "pipeline_run",
+		EntityID:   &entityID,
+		Actor:      "system",
+		Details:    raw,
+		CreatedAt:  now,
+	}
+	if err := r.auditLog.Create(context.Background(), entry); err != nil {
+		r.logger.Warn("stale run reconciler audit log write failed",
+			slog.String("run_id", run.ID.String()),
+			slog.Any("error", err),
+		)
+	}
+}

--- a/internal/agent/stale_run_reconciler_test.go
+++ b/internal/agent/stale_run_reconciler_test.go
@@ -1,0 +1,150 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/PatrickFanella/get-rich-quick/internal/domain"
+	"github.com/PatrickFanella/get-rich-quick/internal/repository"
+	"github.com/google/uuid"
+)
+
+type staleRunRepoStub struct {
+	runs    []domain.PipelineRun
+	updates []repository.PipelineRunStatusUpdate
+	ids     []uuid.UUID
+	filter  repository.PipelineRunFilter
+	err     error
+}
+
+func (s *staleRunRepoStub) Create(context.Context, *domain.PipelineRun) error { return nil }
+func (s *staleRunRepoStub) Get(context.Context, uuid.UUID, time.Time) (*domain.PipelineRun, error) {
+	return nil, repository.ErrNotFound
+}
+func (s *staleRunRepoStub) List(_ context.Context, filter repository.PipelineRunFilter, _, _ int) ([]domain.PipelineRun, error) {
+	s.filter = filter
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.runs, nil
+}
+func (s *staleRunRepoStub) Count(context.Context, repository.PipelineRunFilter) (int, error) {
+	return len(s.runs), nil
+}
+func (s *staleRunRepoStub) UpdateStatus(_ context.Context, id uuid.UUID, _ time.Time, update repository.PipelineRunStatusUpdate) error {
+	s.ids = append(s.ids, id)
+	s.updates = append(s.updates, update)
+	return nil
+}
+
+type staleAuditLogStub struct {
+	entries []*domain.AuditLogEntry
+	err     error
+}
+
+func (s *staleAuditLogStub) Create(_ context.Context, entry *domain.AuditLogEntry) error {
+	if s.err != nil {
+		return s.err
+	}
+	s.entries = append(s.entries, entry)
+	return nil
+}
+func (s *staleAuditLogStub) Query(context.Context, repository.AuditLogFilter, int, int) ([]domain.AuditLogEntry, error) {
+	return nil, nil
+}
+func (s *staleAuditLogStub) Count(context.Context, repository.AuditLogFilter) (int, error) {
+	return len(s.entries), nil
+}
+
+type staleMetricStub struct{ count int }
+
+func (s *staleMetricStub) RecordStaleRunReconciled() { s.count++ }
+
+func TestStaleRunReconcilerReconcile_MarksRunsFailedAndCancels(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 4, 11, 12, 0, 0, 0, time.UTC)
+	staleRun := domain.PipelineRun{
+		ID:        uuid.New(),
+		TradeDate: now.Truncate(24 * time.Hour),
+		Status:    domain.PipelineStatusRunning,
+		StartedAt: now.Add(-45 * time.Minute),
+	}
+	repo := &staleRunRepoStub{runs: []domain.PipelineRun{staleRun}}
+	audit := &staleAuditLogStub{}
+	metrics := &staleMetricStub{}
+	registry := NewRunContextRegistry()
+	cancelled := false
+	registry.Register(staleRun.ID, func() { cancelled = true })
+
+	reconciler := NewStaleRunReconciler(repo, audit, registry, metrics, nil, StaleRunReconcilerConfig{
+		TTL:      30 * time.Minute,
+		Interval: time.Minute,
+		Clock:    func() time.Time { return now },
+	})
+
+	count, err := reconciler.Reconcile(context.Background())
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("Reconcile() count = %d, want 1", count)
+	}
+	if repo.filter.Status != domain.PipelineStatusRunning {
+		t.Fatalf("filter.Status = %q, want %q", repo.filter.Status, domain.PipelineStatusRunning)
+	}
+	if repo.filter.StartedBefore == nil || !repo.filter.StartedBefore.Equal(now.Add(-30*time.Minute)) {
+		t.Fatalf("StartedBefore = %v, want %v", repo.filter.StartedBefore, now.Add(-30*time.Minute))
+	}
+	if len(repo.updates) != 1 {
+		t.Fatalf("updates = %d, want 1", len(repo.updates))
+	}
+	if repo.updates[0].Status != domain.PipelineStatusFailed {
+		t.Fatalf("update.Status = %q, want %q", repo.updates[0].Status, domain.PipelineStatusFailed)
+	}
+	if repo.updates[0].CompletedAt == nil || !repo.updates[0].CompletedAt.Equal(now) {
+		t.Fatalf("CompletedAt = %v, want %v", repo.updates[0].CompletedAt, now)
+	}
+	if repo.updates[0].ErrorMessage != "stale run: exceeded TTL" {
+		t.Fatalf("ErrorMessage = %q", repo.updates[0].ErrorMessage)
+	}
+	if !cancelled {
+		t.Fatal("expected registry cancel func to be called")
+	}
+	if metrics.count != 1 {
+		t.Fatalf("metrics count = %d, want 1", metrics.count)
+	}
+	if len(audit.entries) != 1 {
+		t.Fatalf("audit entries = %d, want 1", len(audit.entries))
+	}
+	if audit.entries[0].EventType != "pipeline_run.stale_reconciled" {
+		t.Fatalf("audit event = %q", audit.entries[0].EventType)
+	}
+	var details map[string]any
+	if err := json.Unmarshal(audit.entries[0].Details, &details); err != nil {
+		t.Fatalf("unmarshal audit details: %v", err)
+	}
+	if details["reason"] != "stale run: exceeded TTL" {
+		t.Fatalf("audit reason = %v", details["reason"])
+	}
+}
+
+func TestStaleRunReconcilerReconcile_SkipsWhenRepoFails(t *testing.T) {
+	t.Parallel()
+
+	reconciler := NewStaleRunReconciler(&staleRunRepoStub{err: errors.New("boom")}, nil, nil, nil, nil, StaleRunReconcilerConfig{
+		TTL:   time.Minute,
+		Clock: time.Now,
+	})
+
+	count, err := reconciler.Reconcile(context.Background())
+	if err == nil {
+		t.Fatal("Reconcile() error = nil, want error")
+	}
+	if count != 0 {
+		t.Fatalf("Reconcile() count = %d, want 0", count)
+	}
+}

--- a/internal/automation/orchestrator.go
+++ b/internal/automation/orchestrator.go
@@ -60,33 +60,39 @@ type OrchestratorDeps struct {
 
 // RegisteredJob tracks a single automated job and its runtime state.
 type RegisteredJob struct {
-	Name        string
-	Description string
-	Schedule    scheduler.ScheduleSpec
-	Fn          func(ctx context.Context) error
-	DependsOn   []string // job names that must not be running
-	mu          sync.Mutex
-	LastRun     *time.Time
-	LastResult  string
-	LastError   string
-	RunCount    int
-	ErrorCount  int
-	Running     bool
-	Enabled     bool
+	Name                string
+	Description         string
+	Schedule            scheduler.ScheduleSpec
+	Fn                  func(ctx context.Context) error
+	DependsOn           []string // job names that must not be running
+	mu                  sync.Mutex
+	StartedAt           *time.Time
+	LastRun             *time.Time
+	LastResult          string
+	LastError           string
+	LastErrorAt         *time.Time
+	RunCount            int
+	ErrorCount          int
+	ConsecutiveFailures int
+	Running             bool
+	Enabled             bool
 }
 
 // JobStatus is the read-only snapshot returned by Status.
 type JobStatus struct {
-	Name        string     `json:"name"`
-	Description string     `json:"description"`
-	Schedule    string     `json:"schedule"`
-	LastRun     *time.Time `json:"last_run,omitempty"`
-	LastResult  string     `json:"last_result"`
-	LastError   string     `json:"last_error,omitempty"`
-	RunCount    int        `json:"run_count"`
-	ErrorCount  int        `json:"error_count"`
-	Running     bool       `json:"running"`
-	Enabled     bool       `json:"enabled"`
+	Name                string         `json:"name"`
+	Description         string         `json:"description"`
+	Schedule            string         `json:"schedule"`
+	LastRun             *time.Time     `json:"last_run,omitempty"`
+	LastResult          string         `json:"last_result"`
+	LastError           string         `json:"last_error,omitempty"`
+	LastErrorAt         *time.Time     `json:"last_error_at,omitempty"`
+	RunCount            int            `json:"run_count"`
+	ErrorCount          int            `json:"error_count"`
+	ConsecutiveFailures int            `json:"consecutive_failures"`
+	StuckFor            *time.Duration `json:"stuck_for,omitempty"`
+	Running             bool           `json:"running"`
+	Enabled             bool           `json:"enabled"`
 }
 
 // JobOrchestrator is the central registry and cron runner for all automated jobs.
@@ -172,17 +178,25 @@ func (o *JobOrchestrator) Status() []JobStatus {
 	statuses := make([]JobStatus, 0, len(o.jobs))
 	for _, job := range o.jobs {
 		job.mu.Lock()
+		var stuckFor *time.Duration
+		if job.Running && job.StartedAt != nil {
+			d := time.Since(*job.StartedAt)
+			stuckFor = &d
+		}
 		s := JobStatus{
-			Name:        job.Name,
-			Description: job.Description,
-			Schedule:    job.Schedule.Describe(),
-			LastRun:     job.LastRun,
-			LastResult:  job.LastResult,
-			LastError:   job.LastError,
-			RunCount:    job.RunCount,
-			ErrorCount:  job.ErrorCount,
-			Running:     job.Running,
-			Enabled:     job.Enabled,
+			Name:                job.Name,
+			Description:         job.Description,
+			Schedule:            job.Schedule.Describe(),
+			LastRun:             job.LastRun,
+			LastResult:          job.LastResult,
+			LastError:           job.LastError,
+			LastErrorAt:         job.LastErrorAt,
+			RunCount:            job.RunCount,
+			ErrorCount:          job.ErrorCount,
+			ConsecutiveFailures: job.ConsecutiveFailures,
+			StuckFor:            stuckFor,
+			Running:             job.Running,
+			Enabled:             job.Enabled,
 		}
 		job.mu.Unlock()
 		statuses = append(statuses, s)
@@ -213,7 +227,9 @@ func (o *JobOrchestrator) runDirect(job *RegisteredJob) {
 		o.logger.Warn("automation: skipping overlapping run", slog.String("job", job.Name))
 		return
 	}
+	startedAt := time.Now()
 	job.Running = true
+	job.StartedAt = &startedAt
 	job.mu.Unlock()
 
 	// Check dependencies.
@@ -238,6 +254,7 @@ func (o *JobOrchestrator) runDirect(job *RegisteredJob) {
 	defer func() {
 		job.mu.Lock()
 		job.Running = false
+		job.StartedAt = nil
 		job.mu.Unlock()
 	}()
 
@@ -254,10 +271,13 @@ func (o *JobOrchestrator) runDirect(job *RegisteredJob) {
 		job.ErrorCount++
 		job.LastResult = "failed"
 		job.LastError = err.Error()
+		job.LastErrorAt = &now
+		job.ConsecutiveFailures++
 		o.logger.Error("automation: job failed", slog.String("job", job.Name), slog.Duration("elapsed", elapsed), slog.Any("error", err))
 	} else {
 		job.LastResult = "success"
 		job.LastError = ""
+		job.ConsecutiveFailures = 0
 		o.logger.Info("automation: job completed", slog.String("job", job.Name), slog.Duration("elapsed", elapsed))
 	}
 	job.mu.Unlock()
@@ -299,7 +319,9 @@ func (o *JobOrchestrator) wrapAndRun(job *RegisteredJob) {
 		o.logger.Warn("automation: skipping overlapping run", slog.String("job", job.Name))
 		return
 	}
+	startedAt := time.Now()
 	job.Running = true
+	job.StartedAt = &startedAt
 	job.mu.Unlock()
 
 	// Check dependencies — skip if any dependency is currently running.
@@ -324,6 +346,7 @@ func (o *JobOrchestrator) wrapAndRun(job *RegisteredJob) {
 	defer func() {
 		job.mu.Lock()
 		job.Running = false
+		job.StartedAt = nil
 		job.mu.Unlock()
 	}()
 
@@ -341,9 +364,12 @@ func (o *JobOrchestrator) wrapAndRun(job *RegisteredJob) {
 	if err != nil {
 		job.ErrorCount++
 		job.LastError = err.Error()
+		job.LastErrorAt = &now
+		job.ConsecutiveFailures++
 		job.LastResult = fmt.Sprintf("error after %s", elapsed.Truncate(time.Millisecond))
 	} else {
 		job.LastError = ""
+		job.ConsecutiveFailures = 0
 		job.LastResult = fmt.Sprintf("ok in %s", elapsed.Truncate(time.Millisecond))
 	}
 	job.mu.Unlock()
@@ -417,8 +443,10 @@ func (o *JobOrchestrator) hydrateFromDB() {
 		job.LastRun = s.LastRun
 		job.LastResult = s.LastResult
 		job.LastError = s.LastError
+		job.LastErrorAt = s.LastErrorAt
 		job.RunCount = s.RunCount
 		job.ErrorCount = s.ErrorCount
+		job.ConsecutiveFailures = s.ConsecutiveFailures
 		job.mu.Unlock()
 	}
 

--- a/internal/automation/orchestrator_test.go
+++ b/internal/automation/orchestrator_test.go
@@ -1,0 +1,120 @@
+package automation
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/PatrickFanella/get-rich-quick/internal/scheduler"
+)
+
+func TestJobOrchestratorRunJob_TracksFailureFieldsAndReset(t *testing.T) {
+	t.Parallel()
+
+	orch := NewJobOrchestrator(OrchestratorDeps{})
+	shouldFail := true
+	orch.Register("job", "test job", schedulerSpecEveryMinute(), func(context.Context) error {
+		if shouldFail {
+			return errors.New("boom")
+		}
+		return nil
+	})
+
+	if err := orch.RunJob(context.Background(), "job"); err != nil {
+		t.Fatalf("RunJob(first) error = %v", err)
+	}
+	waitForJobRuns(t, orch, "job", 1)
+
+	status := singleJobStatus(t, orch, "job")
+	if status.LastResult != "failed" {
+		t.Fatalf("LastResult = %q, want failed", status.LastResult)
+	}
+	if status.LastError != "boom" {
+		t.Fatalf("LastError = %q, want boom", status.LastError)
+	}
+	if status.LastErrorAt == nil {
+		t.Fatal("LastErrorAt = nil, want timestamp")
+	}
+	if status.ConsecutiveFailures != 1 {
+		t.Fatalf("ConsecutiveFailures = %d, want 1", status.ConsecutiveFailures)
+	}
+
+	shouldFail = false
+	if err := orch.RunJob(context.Background(), "job"); err != nil {
+		t.Fatalf("RunJob(second) error = %v", err)
+	}
+	waitForJobRuns(t, orch, "job", 2)
+
+	status = singleJobStatus(t, orch, "job")
+	if status.LastResult != "success" {
+		t.Fatalf("LastResult = %q, want success", status.LastResult)
+	}
+	if status.LastError != "" {
+		t.Fatalf("LastError = %q, want empty", status.LastError)
+	}
+	if status.ConsecutiveFailures != 0 {
+		t.Fatalf("ConsecutiveFailures = %d, want 0", status.ConsecutiveFailures)
+	}
+}
+
+func TestJobOrchestratorStatus_IncludesStuckForWhenRunning(t *testing.T) {
+	t.Parallel()
+
+	orch := NewJobOrchestrator(OrchestratorDeps{})
+	started := make(chan struct{})
+	release := make(chan struct{})
+	orch.Register("job", "blocking job", schedulerSpecEveryMinute(), func(context.Context) error {
+		close(started)
+		<-release
+		return nil
+	})
+
+	if err := orch.RunJob(context.Background(), "job"); err != nil {
+		t.Fatalf("RunJob() error = %v", err)
+	}
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("job did not start")
+	}
+
+	status := singleJobStatus(t, orch, "job")
+	if !status.Running {
+		t.Fatal("Running = false, want true")
+	}
+	if status.StuckFor == nil || *status.StuckFor <= 0 {
+		t.Fatalf("StuckFor = %v, want > 0", status.StuckFor)
+	}
+
+	close(release)
+	waitForJobRuns(t, orch, "job", 1)
+}
+
+func waitForJobRuns(t *testing.T, orch *JobOrchestrator, jobName string, want int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		status := singleJobStatus(t, orch, jobName)
+		if status.RunCount >= want && !status.Running {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("job %s did not reach run_count=%d", jobName, want)
+}
+
+func singleJobStatus(t *testing.T, orch *JobOrchestrator, jobName string) JobStatus {
+	t.Helper()
+	for _, status := range orch.Status() {
+		if status.Name == jobName {
+			return status
+		}
+	}
+	t.Fatalf("job status %q not found", jobName)
+	return JobStatus{}
+}
+
+func schedulerSpecEveryMinute() scheduler.ScheduleSpec {
+	return scheduler.ScheduleSpec{Cron: "* * * * *", Type: scheduler.ScheduleTypeCron}
+}

--- a/internal/execution/order_manager.go
+++ b/internal/execution/order_manager.go
@@ -73,6 +73,12 @@ type OrderManager struct {
 	logger         *slog.Logger
 	nowMu          sync.RWMutex
 	nowFunc        func() time.Time
+	metrics        OrderMetricsRecorder
+}
+
+// OrderMetricsRecorder records order lifecycle metrics.
+type OrderMetricsRecorder interface {
+	RecordOrder(broker, side, status string)
 }
 
 // NewOrderManager constructs an OrderManager with the given dependencies.
@@ -105,6 +111,15 @@ func NewOrderManager(
 		logger:         logger,
 		nowFunc:        time.Now,
 	}
+}
+
+// WithMetrics wires an optional metrics recorder into the manager.
+func (m *OrderManager) WithMetrics(metrics OrderMetricsRecorder) *OrderManager {
+	if m == nil {
+		return nil
+	}
+	m.metrics = metrics
+	return m
 }
 
 // SetNowFunc overrides the order manager time source, allowing callers to
@@ -256,6 +271,7 @@ func (m *OrderManager) ProcessSignal(
 	if err := m.orderRepo.Create(ctx, order); err != nil {
 		return fmt.Errorf("order_manager: create order: %w", err)
 	}
+	m.recordOrderMetric(order.Side, order.Status)
 
 	if auditErr := m.audit(ctx, "order_created", "order", &order.ID, map[string]any{
 		"ticker":      plan.Ticker,
@@ -279,6 +295,7 @@ func (m *OrderManager) ProcessSignal(
 		if updateErr := m.orderRepo.Update(ctx, order); updateErr != nil {
 			m.logger.ErrorContext(ctx, "failed to update rejected order", "error", updateErr)
 		}
+		m.recordOrderMetric(order.Side, order.Status)
 
 		if auditErr := m.audit(ctx, "pre_trade_rejected", "order", &order.ID, map[string]any{
 			"reason": reason,
@@ -296,6 +313,7 @@ func (m *OrderManager) ProcessSignal(
 		if updateErr := m.orderRepo.Update(ctx, order); updateErr != nil {
 			m.logger.ErrorContext(ctx, "failed to update rejected order", "error", updateErr)
 		}
+		m.recordOrderMetric(order.Side, order.Status)
 
 		if auditErr := m.audit(ctx, "order_rejected", "order", &order.ID, map[string]any{
 			"error": err.Error(),
@@ -316,6 +334,7 @@ func (m *OrderManager) ProcessSignal(
 	if err := m.orderRepo.Update(ctx, order); err != nil {
 		return fmt.Errorf("order_manager: update submitted order: %w", err)
 	}
+	m.recordOrderMetric(order.Side, order.Status)
 
 	if auditErr := m.audit(ctx, "order_submitted", "order", &order.ID, map[string]any{
 		"external_id": externalID,
@@ -340,6 +359,7 @@ func (m *OrderManager) ProcessSignal(
 		if err := m.orderRepo.Update(ctx, order); err != nil {
 			return fmt.Errorf("order_manager: update %s order: %w", status, err)
 		}
+		m.recordOrderMetric(order.Side, order.Status)
 
 		if auditErr := m.audit(ctx, "order_"+string(status), "order", &order.ID, nil); auditErr != nil {
 			m.logger.ErrorContext(ctx, "audit log failed", "error", auditErr)
@@ -352,6 +372,7 @@ func (m *OrderManager) ProcessSignal(
 		if err := m.orderRepo.Update(ctx, order); err != nil {
 			return fmt.Errorf("order_manager: update %s order: %w", status, err)
 		}
+		m.recordOrderMetric(order.Side, order.Status)
 
 		if auditErr := m.audit(ctx, "order_"+string(status), "order", &order.ID, nil); auditErr != nil {
 			m.logger.ErrorContext(ctx, "audit log failed", "error", auditErr)
@@ -365,6 +386,7 @@ func (m *OrderManager) ProcessSignal(
 		if err := m.orderRepo.Update(ctx, order); err != nil {
 			return fmt.Errorf("order_manager: update order status: %w", err)
 		}
+		m.recordOrderMetric(order.Side, order.Status)
 
 		return nil
 	}
@@ -388,6 +410,7 @@ func (m *OrderManager) handleFill(
 	if err := m.orderRepo.Update(ctx, order); err != nil {
 		return fmt.Errorf("order_manager: update filled order: %w", err)
 	}
+	m.recordOrderMetric(order.Side, order.Status)
 
 	// Determine fill price.
 	fillPrice := plan.EntryPrice
@@ -557,4 +580,11 @@ func (m *OrderManager) emitOrderEvent(
 	if err := m.agentEventRepo.Create(ctx, event); err != nil {
 		m.logger.ErrorContext(ctx, "order_manager: emit order event", "error", err, "kind", eventKind)
 	}
+}
+
+func (m *OrderManager) recordOrderMetric(side domain.OrderSide, status domain.OrderStatus) {
+	if m == nil || m.metrics == nil {
+		return
+	}
+	m.metrics.RecordOrder(m.brokerName, string(side), string(status))
 }

--- a/internal/execution/order_manager_test.go
+++ b/internal/execution/order_manager_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"log/slog"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -432,6 +433,12 @@ type mockAgentEventRepo struct {
 	events []*domain.AgentEvent
 
 	createFn func(ctx context.Context, event *domain.AgentEvent) error
+}
+
+type mockOrderMetrics struct{ records []string }
+
+func (m *mockOrderMetrics) RecordOrder(broker, side, status string) {
+	m.records = append(m.records, broker+":"+side+":"+status)
 }
 
 func (r *mockAgentEventRepo) Create(ctx context.Context, event *domain.AgentEvent) error {
@@ -1074,6 +1081,29 @@ func TestProcessSignal_LimitOrder(t *testing.T) {
 		t.Error("expected limit price to be set")
 	} else if *order.LimitPrice != 150.0 {
 		t.Errorf("expected limit price 150.0, got %f", *order.LimitPrice)
+	}
+}
+
+func TestProcessSignal_RecordsOrderMetrics(t *testing.T) {
+	broker := &mockBroker{}
+	riskEng := &mockRiskEngine{}
+	orderRepo := &mockOrderRepo{}
+	positionRepo := &mockPositionRepo{}
+	tradeRepo := &mockTradeRepo{}
+	auditRepo := &mockAuditLogRepo{}
+	metrics := &mockOrderMetrics{}
+
+	mgr := newTestOrderManager(broker, riskEng, orderRepo, positionRepo, tradeRepo, auditRepo).WithMetrics(metrics)
+
+	err := mgr.ProcessSignal(context.Background(), defaultSignal(), defaultPlan(), uuid.New(), uuid.New())
+	if err != nil {
+		t.Fatalf("ProcessSignal() unexpected error: %v", err)
+	}
+
+	for _, want := range []string{"paper:buy:pending", "paper:buy:submitted", "paper:buy:filled"} {
+		if !slices.Contains(metrics.records, want) {
+			t.Fatalf("metrics records = %v, want entry %q", metrics.records, want)
+		}
 	}
 }
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -16,6 +16,7 @@ type Metrics struct {
 	LLMTokensTotal      *prometheus.CounterVec
 	LLMLatency          *prometheus.HistogramVec
 	OrdersTotal         *prometheus.CounterVec
+	StaleRunsReconciled prometheus.Counter
 	PortfolioValue      prometheus.Gauge
 	PositionsOpen       prometheus.Gauge
 	CircuitBreakerState prometheus.Gauge
@@ -65,6 +66,11 @@ func New() *Metrics {
 			Help: "Total orders by broker, side, and status.",
 		}, []string{"broker", "side", "status"}),
 
+		StaleRunsReconciled: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "tradingagent_stale_runs_reconciled_total",
+			Help: "Total number of stale pipeline runs force-failed by the reconciler.",
+		}),
+
 		PortfolioValue: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: "tradingagent_portfolio_value",
 			Help: "Current portfolio value.",
@@ -93,6 +99,7 @@ func New() *Metrics {
 		m.LLMTokensTotal,
 		m.LLMLatency,
 		m.OrdersTotal,
+		m.StaleRunsReconciled,
 		m.PortfolioValue,
 		m.PositionsOpen,
 		m.CircuitBreakerState,
@@ -125,6 +132,10 @@ func (m *Metrics) ObserveLLMLatency(provider, model string, seconds float64) {
 
 func (m *Metrics) RecordOrder(broker, side, status string) {
 	m.OrdersTotal.WithLabelValues(broker, side, status).Inc()
+}
+
+func (m *Metrics) RecordStaleRunReconciled() {
+	m.StaleRunsReconciled.Inc()
 }
 
 func (m *Metrics) SetPortfolioValue(value float64) {

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -35,6 +35,9 @@ func TestNew(t *testing.T) {
 	if m.OrdersTotal == nil {
 		t.Fatal("OrdersTotal is nil")
 	}
+	if m.StaleRunsReconciled == nil {
+		t.Fatal("StaleRunsReconciled is nil")
+	}
 	if m.PortfolioValue == nil {
 		t.Fatal("PortfolioValue is nil")
 	}
@@ -60,6 +63,7 @@ func TestConvenienceMethods(t *testing.T) {
 	m.RecordLLMTokens(100, 200)
 	m.ObserveLLMLatency("openai", "gpt-4", 0.8)
 	m.RecordOrder("alpaca", "buy", "filled")
+	m.RecordStaleRunReconciled()
 	m.SetPortfolioValue(50000.0)
 	m.SetPositionsOpen(3)
 	m.SetCircuitBreakerState(true)
@@ -79,6 +83,7 @@ func TestHandler(t *testing.T) {
 	m.RecordLLMTokens(100, 200)
 	m.ObserveLLMLatency("openai", "gpt-4", 0.8)
 	m.RecordOrder("alpaca", "buy", "filled")
+	m.RecordStaleRunReconciled()
 
 	h := m.Handler()
 	if h == nil {
@@ -102,6 +107,7 @@ func TestHandler(t *testing.T) {
 		"tradingagent_llm_tokens_total",
 		"tradingagent_llm_latency_seconds",
 		"tradingagent_orders_total",
+		"tradingagent_stale_runs_reconciled_total",
 		"tradingagent_portfolio_value",
 		"tradingagent_positions_open",
 		"tradingagent_circuit_breaker_state",

--- a/internal/repository/postgres/job_run.go
+++ b/internal/repository/postgres/job_run.go
@@ -23,12 +23,14 @@ type JobRun struct {
 
 // JobRunSummary holds aggregate stats for a single job name.
 type JobRunSummary struct {
-	JobName    string     `json:"job_name"`
-	LastRun    *time.Time `json:"last_run,omitempty"`
-	LastResult string     `json:"last_result"`
-	LastError  string     `json:"last_error,omitempty"`
-	RunCount   int        `json:"run_count"`
-	ErrorCount int        `json:"error_count"`
+	JobName             string     `json:"job_name"`
+	LastRun             *time.Time `json:"last_run,omitempty"`
+	LastResult          string     `json:"last_result"`
+	LastError           string     `json:"last_error,omitempty"`
+	LastErrorAt         *time.Time `json:"last_error_at,omitempty"`
+	RunCount            int        `json:"run_count"`
+	ErrorCount          int        `json:"error_count"`
+	ConsecutiveFailures int        `json:"consecutive_failures"`
 }
 
 // JobRunRepo persists automation job runs to PostgreSQL.
@@ -124,18 +126,47 @@ func (r *JobRunRepo) Summaries(ctx context.Context) ([]JobRunSummary, error) {
 	for i, s := range summaries {
 		var status string
 		var errStr *string
+		var startedAt time.Time
 		err := r.pool.QueryRow(ctx,
-			`SELECT status, error FROM automation_job_runs
+			`SELECT status, error, started_at FROM automation_job_runs
 			 WHERE job_name = $1 ORDER BY started_at DESC LIMIT 1`,
 			s.JobName,
-		).Scan(&status, &errStr)
+		).Scan(&status, &errStr, &startedAt)
 		if err == nil {
 			summaries[i].LastResult = status
 			if errStr != nil {
 				summaries[i].LastError = *errStr
+				summaries[i].LastErrorAt = &startedAt
 			}
+			summaries[i].ConsecutiveFailures = r.countConsecutiveFailures(ctx, s.JobName)
 		}
 	}
 
 	return summaries, nil
+}
+
+func (r *JobRunRepo) countConsecutiveFailures(ctx context.Context, jobName string) int {
+	rows, err := r.pool.Query(ctx,
+		`SELECT status FROM automation_job_runs
+		 WHERE job_name = $1
+		 ORDER BY started_at DESC`,
+		jobName,
+	)
+	if err != nil {
+		return 0
+	}
+	defer rows.Close()
+
+	count := 0
+	for rows.Next() {
+		var status string
+		if err := rows.Scan(&status); err != nil {
+			return count
+		}
+		if status != "error" {
+			break
+		}
+		count++
+	}
+	return count
 }

--- a/internal/repository/postgres/polymarket_account.go
+++ b/internal/repository/postgres/polymarket_account.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -140,12 +141,16 @@ func (r *PolymarketAccountRepo) InsertTrades(ctx context.Context, trades []domai
 	defer func() { _ = tx.Rollback(ctx) }()
 
 	for _, t := range trades {
-		_, err := tx.Exec(ctx, `
+		normalizedSide, err := normalizePolymarketTradeSide(t.Side)
+		if err != nil {
+			return fmt.Errorf("postgres: normalize trade side for %s: %w", t.AccountAddress, err)
+		}
+		_, err = tx.Exec(ctx, `
 			INSERT INTO polymarket_account_trades
 				(account_address, market_slug, side, action, price, size_usdc, timestamp, outcome, pnl)
 			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
 			ON CONFLICT DO NOTHING`,
-			t.AccountAddress, t.MarketSlug, t.Side, t.Action,
+			t.AccountAddress, t.MarketSlug, normalizedSide, t.Action,
 			t.Price, t.SizeUSDC, t.Timestamp, nilStr(t.Outcome), t.PnL,
 		)
 		if err != nil {
@@ -202,6 +207,25 @@ func (r *PolymarketAccountRepo) MarkTracked(ctx context.Context, minWinRate floa
 		return 0, fmt.Errorf("postgres: mark tracked: %w", err)
 	}
 	return result.RowsAffected(), nil
+}
+
+func normalizePolymarketTradeSide(side string) (string, error) {
+	switch strings.ToUpper(strings.TrimSpace(side)) {
+	case "YES":
+		return "YES", nil
+	case "NO":
+		return "NO", nil
+	case "UP":
+		return "Up", nil
+	case "DOWN":
+		return "Down", nil
+	case "OVER":
+		return "Over", nil
+	case "UNDER":
+		return "Under", nil
+	default:
+		return "", fmt.Errorf("unsupported side %q", side)
+	}
 }
 
 // scanAccount scans one row into a PolymarketAccount.

--- a/internal/repository/postgres/polymarket_account_test.go
+++ b/internal/repository/postgres/polymarket_account_test.go
@@ -1,0 +1,43 @@
+package postgres
+
+import "testing"
+
+func TestNormalizePolymarketTradeSide(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{name: "yes lowercase", input: "yes", want: "YES"},
+		{name: "no spaced", input: " no ", want: "NO"},
+		{name: "up mixed", input: "uP", want: "Up"},
+		{name: "down", input: "DOWN", want: "Down"},
+		{name: "over", input: "over", want: "Over"},
+		{name: "under", input: "Under", want: "Under"},
+		{name: "invalid", input: "sideways", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := normalizePolymarketTradeSide(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("normalizePolymarketTradeSide(%q) error = nil, want error", tc.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("normalizePolymarketTradeSide(%q) error = %v", tc.input, err)
+			}
+			if got != tc.want {
+				t.Fatalf("normalizePolymarketTradeSide(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/signal/evaluator.go
+++ b/internal/signal/evaluator.go
@@ -64,7 +64,7 @@ recommended_action:
 Only include strategy IDs that are genuinely affected by this signal.`
 
 // Evaluate scores a signal event against the provided strategies.
-// On LLM failure, returns a fallback EvaluatedSignal with urgency 3 rather than an error.
+// On LLM failure, returns a low-urgency fallback EvaluatedSignal rather than an error.
 // Returns nil if strategies is empty.
 func (e *Evaluator) Evaluate(ctx context.Context, event RawSignalEvent, strategies []StrategyContext) (*EvaluatedSignal, error) {
 	if len(strategies) == 0 {
@@ -171,14 +171,10 @@ func (e *Evaluator) parseResponse(content string, event RawSignalEvent, strategi
 }
 
 func (e *Evaluator) fallback(event RawSignalEvent, strategies []StrategyContext) *EvaluatedSignal {
-	ids := make([]uuid.UUID, len(strategies))
-	for i, s := range strategies {
-		ids[i] = s.ID
-	}
 	return &EvaluatedSignal{
 		Raw:                event,
-		AffectedStrategies: ids,
-		Urgency:            3,
+		AffectedStrategies: nil,
+		Urgency:            1,
 		Summary:            event.Title,
 		RecommendedAction:  "monitor",
 	}

--- a/internal/signal/evaluator_test.go
+++ b/internal/signal/evaluator_test.go
@@ -1,0 +1,103 @@
+package signal
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/PatrickFanella/get-rich-quick/internal/llm"
+	"github.com/google/uuid"
+)
+
+type stubEvaluatorProvider struct {
+	response *llm.CompletionResponse
+	err      error
+}
+
+func (s stubEvaluatorProvider) Complete(context.Context, llm.CompletionRequest) (*llm.CompletionResponse, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.response, nil
+}
+
+func TestEvaluatorEvaluate_ProviderErrorFallsBackToLowUrgency(t *testing.T) {
+	t.Parallel()
+
+	strategyID := uuid.New()
+	evaluator := NewEvaluator(stubEvaluatorProvider{err: errors.New("boom")}, "quick", nil)
+
+	got, err := evaluator.Evaluate(context.Background(), RawSignalEvent{Source: "rss", Title: "headline"}, []StrategyContext{{ID: strategyID}})
+	if err != nil {
+		t.Fatalf("Evaluate() error = %v", err)
+	}
+	if got == nil {
+		t.Fatal("Evaluate() = nil")
+	}
+	if got.Urgency != 1 {
+		t.Fatalf("Urgency = %d, want 1", got.Urgency)
+	}
+	if len(got.AffectedStrategies) != 0 {
+		t.Fatalf("AffectedStrategies = %v, want empty", got.AffectedStrategies)
+	}
+	if got.RecommendedAction != "monitor" {
+		t.Fatalf("RecommendedAction = %q, want monitor", got.RecommendedAction)
+	}
+}
+
+func TestEvaluatorParseResponse_InvalidJSONFallsBackToLowUrgency(t *testing.T) {
+	t.Parallel()
+
+	evaluator := NewEvaluator(stubEvaluatorProvider{response: &llm.CompletionResponse{Content: "not-json"}}, "quick", nil)
+
+	got, err := evaluator.Evaluate(context.Background(), RawSignalEvent{Source: "rss", Title: "headline"}, []StrategyContext{{ID: uuid.New()}})
+	if err != nil {
+		t.Fatalf("Evaluate() error = %v", err)
+	}
+	if got == nil {
+		t.Fatal("Evaluate() = nil")
+	}
+	if got.Urgency != 1 {
+		t.Fatalf("Urgency = %d, want 1", got.Urgency)
+	}
+	if len(got.AffectedStrategies) != 0 {
+		t.Fatalf("AffectedStrategies = %v, want empty", got.AffectedStrategies)
+	}
+}
+
+func TestSignalHubProcess_DropsLowUrgencyFallback(t *testing.T) {
+	t.Parallel()
+
+	strategyID := uuid.New()
+	triggerCh := make(chan TriggerEvent, 1)
+	hub := NewSignalHub(
+		nil,
+		NewEvaluator(stubEvaluatorProvider{err: errors.New("boom")}, "quick", nil),
+		NewWatchIndex(),
+		stubStrategyProvider{strategies: []StrategyWithThesis{{ID: strategyID, Ticker: "AAPL", WatchTerms: []string{"apple"}}}},
+		triggerCh,
+		nil,
+		nil,
+	)
+	hub.watchIndex.Rebuild([]StrategyWithThesis{{ID: strategyID, Ticker: "AAPL", WatchTerms: []string{"apple"}}})
+
+	hub.process(context.Background(), RawSignalEvent{Source: "rss", Title: "Apple jumps", Body: "apple rally"})
+
+	select {
+	case trigger := <-triggerCh:
+		t.Fatalf("unexpected trigger emitted: %+v", trigger)
+	default:
+	}
+}
+
+type stubStrategyProvider struct {
+	strategies []StrategyWithThesis
+	err        error
+}
+
+func (s stubStrategyProvider) ListActiveWithThesis(context.Context) ([]StrategyWithThesis, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.strategies, nil
+}

--- a/migrations/000026_polymarket_trade_side_widen.down.sql
+++ b/migrations/000026_polymarket_trade_side_widen.down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE polymarket_account_trades DROP CONSTRAINT IF EXISTS polymarket_account_trades_side_check;
+
+ALTER TABLE polymarket_account_trades
+    ADD CONSTRAINT polymarket_account_trades_side_check
+    CHECK (side IN ('YES', 'NO'));

--- a/migrations/000026_polymarket_trade_side_widen.up.sql
+++ b/migrations/000026_polymarket_trade_side_widen.up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE polymarket_account_trades DROP CONSTRAINT IF EXISTS polymarket_account_trades_side_check;
+
+ALTER TABLE polymarket_account_trades
+    ADD CONSTRAINT polymarket_account_trades_side_check
+    CHECK (side IN ('YES', 'NO', 'Up', 'Down', 'Over', 'Under'));


### PR DESCRIPTION
## Summary
- stop evaluator parse fallbacks from triggering unrelated strategies and widen Polymarket side handling/storage
- add stale-run reconciliation, env-backed debate timeout downgrade, and runtime metrics emission across pipeline/LLM/order paths
- expose richer automation job health metadata and align reference docs with shipped runtime behavior

## Testing
- go test ./internal/signal ./internal/repository/postgres ./cmd/tradingagent
- go test ./internal/agent ./internal/metrics ./cmd/tradingagent
- go test ./internal/execution ./cmd/tradingagent
- go test ./internal/automation ./internal/repository/postgres
- go vet ./internal/agent ./internal/metrics ./cmd/tradingagent
- go vet ./internal/execution ./cmd/tradingagent
- go vet ./internal/automation ./internal/repository/postgres

Closes #607