### PR TITLE
feat(llm): add provider chain builder and budget guard

### DIFF
--- a/internal/llm/budget.go
+++ b/internal/llm/budget.go
@@ -1,0 +1,147 @@
+package llm
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+)
+
+// ErrBudgetExhausted is returned when daily request or token budget is spent.
+// RetryProvider treats this as non-retryable (unknown error type, no statusCoder).
+var ErrBudgetExhausted = errors.New("llm: daily budget exhausted")
+
+// Budget tracks daily request and token usage with thread-safe counters.
+// Zero limits mean unlimited. Call Reset() to clear counters (e.g. at UTC midnight).
+type Budget struct {
+	mu sync.Mutex
+
+	maxRequestsPerDay int
+	maxTokensPerDay   int
+
+	requests         int
+	promptTokens     int
+	completionTokens int
+	resetAt          time.Time
+}
+
+// NewBudget creates a Budget with the given daily limits.
+// Zero values for either limit mean that dimension is unlimited.
+func NewBudget(maxRequestsPerDay, maxTokensPerDay int) *Budget {
+	return &Budget{
+		maxRequestsPerDay: maxRequestsPerDay,
+		maxTokensPerDay:   maxTokensPerDay,
+		resetAt:           nextUTCMidnight(),
+	}
+}
+
+// Allow returns true if a new request is within budget.
+// It auto-resets counters when UTC midnight has passed.
+func (b *Budget) Allow() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.maybeReset()
+
+	if b.maxRequestsPerDay > 0 && b.requests >= b.maxRequestsPerDay {
+		return false
+	}
+	if b.maxTokensPerDay > 0 && (b.promptTokens+b.completionTokens) >= b.maxTokensPerDay {
+		return false
+	}
+	return true
+}
+
+// Record tracks token usage for a completed request.
+func (b *Budget) Record(promptTokens, completionTokens int) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.maybeReset()
+
+	b.requests++
+	b.promptTokens += promptTokens
+	b.completionTokens += completionTokens
+}
+
+// Reset clears all counters and sets the next reset time.
+func (b *Budget) Reset() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.requests = 0
+	b.promptTokens = 0
+	b.completionTokens = 0
+	b.resetAt = nextUTCMidnight()
+}
+
+// Stats returns current budget usage (for observability).
+func (b *Budget) Stats() BudgetStats {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.maybeReset()
+
+	return BudgetStats{
+		Requests:            b.requests,
+		MaxRequestsPerDay:   b.maxRequestsPerDay,
+		PromptTokens:        b.promptTokens,
+		CompletionTokens:    b.completionTokens,
+		TotalTokens:         b.promptTokens + b.completionTokens,
+		MaxTokensPerDay:     b.maxTokensPerDay,
+		ResetAt:             b.resetAt,
+	}
+}
+
+// BudgetStats holds a snapshot of budget usage.
+type BudgetStats struct {
+	Requests          int
+	MaxRequestsPerDay int
+	PromptTokens      int
+	CompletionTokens  int
+	TotalTokens       int
+	MaxTokensPerDay   int
+	ResetAt           time.Time
+}
+
+// maybeReset auto-resets counters when past the reset time. Must hold mu.
+func (b *Budget) maybeReset() {
+	if time.Now().UTC().After(b.resetAt) {
+		b.requests = 0
+		b.promptTokens = 0
+		b.completionTokens = 0
+		b.resetAt = nextUTCMidnight()
+	}
+}
+
+func nextUTCMidnight() time.Time {
+	now := time.Now().UTC()
+	return time.Date(now.Year(), now.Month(), now.Day()+1, 0, 0, 0, 0, time.UTC)
+}
+
+// BudgetGuardProvider wraps a Provider, rejecting calls when budget is exhausted.
+// On success it records token usage back to the budget.
+type BudgetGuardProvider struct {
+	inner  Provider
+	budget *Budget
+}
+
+// NewBudgetGuardProvider wraps inner with budget enforcement.
+func NewBudgetGuardProvider(inner Provider, budget *Budget) *BudgetGuardProvider {
+	return &BudgetGuardProvider{inner: inner, budget: budget}
+}
+
+// Complete checks budget before delegating. Records usage after success.
+func (b *BudgetGuardProvider) Complete(ctx context.Context, req CompletionRequest) (*CompletionResponse, error) {
+	if !b.budget.Allow() {
+		return nil, ErrBudgetExhausted
+	}
+
+	resp, err := b.inner.Complete(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	b.budget.Record(resp.Usage.PromptTokens, resp.Usage.CompletionTokens)
+	return resp, nil
+}

--- a/internal/llm/budget.go
+++ b/internal/llm/budget.go
@@ -168,7 +168,6 @@ func (b *Budget) releaseRequest() {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	b.maybeReset()
 	if b.requests > 0 {
 		b.requests--
 	}

--- a/internal/llm/budget.go
+++ b/internal/llm/budget.go
@@ -83,13 +83,13 @@ func (b *Budget) Stats() BudgetStats {
 	b.maybeReset()
 
 	return BudgetStats{
-		Requests:            b.requests,
-		MaxRequestsPerDay:   b.maxRequestsPerDay,
-		PromptTokens:        b.promptTokens,
-		CompletionTokens:    b.completionTokens,
-		TotalTokens:         b.promptTokens + b.completionTokens,
-		MaxTokensPerDay:     b.maxTokensPerDay,
-		ResetAt:             b.resetAt,
+		Requests:          b.requests,
+		MaxRequestsPerDay: b.maxRequestsPerDay,
+		PromptTokens:      b.promptTokens,
+		CompletionTokens:  b.completionTokens,
+		TotalTokens:       b.promptTokens + b.completionTokens,
+		MaxTokensPerDay:   b.maxTokensPerDay,
+		ResetAt:           b.resetAt,
 	}
 }
 
@@ -106,7 +106,7 @@ type BudgetStats struct {
 
 // maybeReset auto-resets counters when past the reset time. Must hold mu.
 func (b *Budget) maybeReset() {
-	if time.Now().UTC().After(b.resetAt) {
+	if !time.Now().UTC().Before(b.resetAt) {
 		b.requests = 0
 		b.promptTokens = 0
 		b.completionTokens = 0
@@ -133,15 +133,52 @@ func NewBudgetGuardProvider(inner Provider, budget *Budget) *BudgetGuardProvider
 
 // Complete checks budget before delegating. Records usage after success.
 func (b *BudgetGuardProvider) Complete(ctx context.Context, req CompletionRequest) (*CompletionResponse, error) {
-	if !b.budget.Allow() {
+	if !b.budget.reserveRequest() {
 		return nil, ErrBudgetExhausted
 	}
 
 	resp, err := b.inner.Complete(ctx, req)
 	if err != nil {
+		b.budget.releaseRequest()
 		return nil, err
 	}
 
-	b.budget.Record(resp.Usage.PromptTokens, resp.Usage.CompletionTokens)
+	b.budget.recordTokens(resp.Usage.PromptTokens, resp.Usage.CompletionTokens)
 	return resp, nil
+}
+
+func (b *Budget) reserveRequest() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.maybeReset()
+
+	if b.maxRequestsPerDay > 0 && b.requests >= b.maxRequestsPerDay {
+		return false
+	}
+	if b.maxTokensPerDay > 0 && (b.promptTokens+b.completionTokens) >= b.maxTokensPerDay {
+		return false
+	}
+
+	b.requests++
+	return true
+}
+
+func (b *Budget) releaseRequest() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.maybeReset()
+	if b.requests > 0 {
+		b.requests--
+	}
+}
+
+func (b *Budget) recordTokens(promptTokens, completionTokens int) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.maybeReset()
+	b.promptTokens += promptTokens
+	b.completionTokens += completionTokens
 }

--- a/internal/llm/budget_test.go
+++ b/internal/llm/budget_test.go
@@ -3,6 +3,8 @@ package llm_test
 import (
 	"context"
 	"errors"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/PatrickFanella/get-rich-quick/internal/llm"
@@ -159,6 +161,49 @@ func TestBudgetGuardProvider_RecordsUsage(t *testing.T) {
 	if !errors.Is(err, llm.ErrBudgetExhausted) {
 		t.Errorf("call 3 error = %v, want ErrBudgetExhausted", err)
 	}
+}
+
+func TestBudgetGuardProvider_ConcurrentRequestLimit(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	started := make(chan struct{})
+	release := make(chan struct{})
+
+	inner := llm.ProviderFunc(func(_ context.Context, _ llm.CompletionRequest) (*llm.CompletionResponse, error) {
+		calls.Add(1)
+		close(started)
+		<-release
+		return &llm.CompletionResponse{Content: "ok"}, nil
+	})
+
+	budget := llm.NewBudget(1, 0)
+	guard := llm.NewBudgetGuardProvider(inner, budget)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	var err1, err2 error
+	go func() {
+		defer wg.Done()
+		_, err1 = guard.Complete(context.Background(), llm.CompletionRequest{})
+	}()
+	<-started
+	go func() {
+		defer wg.Done()
+		_, err2 = guard.Complete(context.Background(), llm.CompletionRequest{})
+	}()
+
+	close(release)
+	wg.Wait()
+
+	if calls.Load() != 1 {
+		t.Fatalf("inner calls = %d, want 1", calls.Load())
+	}
+	if (errors.Is(err1, llm.ErrBudgetExhausted) && err2 == nil) || (errors.Is(err2, llm.ErrBudgetExhausted) && err1 == nil) {
+		return
+	}
+	t.Fatalf("expected one success and one ErrBudgetExhausted, got err1=%v err2=%v", err1, err2)
 }
 
 func TestErrBudgetExhausted_IsNotRetryable(t *testing.T) {

--- a/internal/llm/budget_test.go
+++ b/internal/llm/budget_test.go
@@ -200,7 +200,9 @@ func TestBudgetGuardProvider_ConcurrentRequestLimit(t *testing.T) {
 	if calls.Load() != 1 {
 		t.Fatalf("inner calls = %d, want 1", calls.Load())
 	}
-	if (errors.Is(err1, llm.ErrBudgetExhausted) && err2 == nil) || (errors.Is(err2, llm.ErrBudgetExhausted) && err1 == nil) {
+	err1Exhausted := errors.Is(err1, llm.ErrBudgetExhausted)
+	err2Exhausted := errors.Is(err2, llm.ErrBudgetExhausted)
+	if (err1 == nil && err2Exhausted) || (err2 == nil && err1Exhausted) {
 		return
 	}
 	t.Fatalf("expected one success and one ErrBudgetExhausted, got err1=%v err2=%v", err1, err2)

--- a/internal/llm/budget_test.go
+++ b/internal/llm/budget_test.go
@@ -1,0 +1,185 @@
+package llm_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/PatrickFanella/get-rich-quick/internal/llm"
+)
+
+func TestBudget_AllowUnlimited(t *testing.T) {
+	t.Parallel()
+
+	b := llm.NewBudget(0, 0) // unlimited
+	for range 100 {
+		if !b.Allow() {
+			t.Fatal("Allow() returned false for unlimited budget")
+		}
+		b.Record(100, 50)
+	}
+}
+
+func TestBudget_RequestLimit(t *testing.T) {
+	t.Parallel()
+
+	b := llm.NewBudget(3, 0)
+
+	for i := range 3 {
+		if !b.Allow() {
+			t.Fatalf("Allow() false at request %d, want true", i+1)
+		}
+		b.Record(10, 5)
+	}
+
+	if b.Allow() {
+		t.Error("Allow() true after 3/3 requests, want false")
+	}
+}
+
+func TestBudget_TokenLimit(t *testing.T) {
+	t.Parallel()
+
+	b := llm.NewBudget(0, 100) // 100 total tokens
+
+	b.Record(40, 30) // 70 total
+	if !b.Allow() {
+		t.Fatal("Allow() false at 70/100 tokens")
+	}
+
+	b.Record(20, 15) // 105 total → over
+	if b.Allow() {
+		t.Error("Allow() true at 105/100 tokens, want false")
+	}
+}
+
+func TestBudget_Reset(t *testing.T) {
+	t.Parallel()
+
+	b := llm.NewBudget(1, 0)
+	b.Record(10, 5)
+
+	if b.Allow() {
+		t.Fatal("Allow() true at 1/1 requests before reset")
+	}
+
+	b.Reset()
+
+	if !b.Allow() {
+		t.Error("Allow() false after Reset(), want true")
+	}
+}
+
+func TestBudget_Stats(t *testing.T) {
+	t.Parallel()
+
+	b := llm.NewBudget(10, 500)
+	b.Record(20, 10)
+	b.Record(30, 15)
+
+	s := b.Stats()
+	if s.Requests != 2 {
+		t.Errorf("Requests = %d, want 2", s.Requests)
+	}
+	if s.PromptTokens != 50 {
+		t.Errorf("PromptTokens = %d, want 50", s.PromptTokens)
+	}
+	if s.CompletionTokens != 25 {
+		t.Errorf("CompletionTokens = %d, want 25", s.CompletionTokens)
+	}
+	if s.TotalTokens != 75 {
+		t.Errorf("TotalTokens = %d, want 75", s.TotalTokens)
+	}
+	if s.MaxRequestsPerDay != 10 {
+		t.Errorf("MaxRequestsPerDay = %d, want 10", s.MaxRequestsPerDay)
+	}
+	if s.MaxTokensPerDay != 500 {
+		t.Errorf("MaxTokensPerDay = %d, want 500", s.MaxTokensPerDay)
+	}
+}
+
+func TestBudgetGuardProvider_Blocks(t *testing.T) {
+	t.Parallel()
+
+	inner := &trackingProvider{
+		response: &llm.CompletionResponse{Content: "ok", Usage: llm.CompletionUsage{PromptTokens: 5, CompletionTokens: 3}},
+	}
+	budget := llm.NewBudget(2, 0)
+	guard := llm.NewBudgetGuardProvider(inner, budget)
+
+	// Two calls succeed
+	for i := range 2 {
+		_, err := guard.Complete(context.Background(), llm.CompletionRequest{})
+		if err != nil {
+			t.Fatalf("call %d: %v", i+1, err)
+		}
+	}
+
+	// Third blocked
+	_, err := guard.Complete(context.Background(), llm.CompletionRequest{})
+	if !errors.Is(err, llm.ErrBudgetExhausted) {
+		t.Errorf("call 3 error = %v, want ErrBudgetExhausted", err)
+	}
+	if inner.calls.Load() != 2 {
+		t.Errorf("inner calls = %d, want 2", inner.calls.Load())
+	}
+}
+
+func TestBudgetGuardProvider_RecordsUsage(t *testing.T) {
+	t.Parallel()
+
+	inner := &trackingProvider{
+		response: &llm.CompletionResponse{
+			Content: "tracked",
+			Usage:   llm.CompletionUsage{PromptTokens: 20, CompletionTokens: 10},
+		},
+	}
+	budget := llm.NewBudget(0, 50) // 50 token limit
+	guard := llm.NewBudgetGuardProvider(inner, budget)
+
+	// First call: 30 tokens
+	_, err := guard.Complete(context.Background(), llm.CompletionRequest{})
+	if err != nil {
+		t.Fatalf("call 1: %v", err)
+	}
+
+	s := budget.Stats()
+	if s.TotalTokens != 30 {
+		t.Errorf("after call 1: TotalTokens = %d, want 30", s.TotalTokens)
+	}
+
+	// Second call: 60 tokens total → over budget
+	_, err = guard.Complete(context.Background(), llm.CompletionRequest{})
+	if err != nil {
+		t.Fatalf("call 2: %v", err)
+	}
+
+	// Third call: blocked (60 ≥ 50)
+	_, err = guard.Complete(context.Background(), llm.CompletionRequest{})
+	if !errors.Is(err, llm.ErrBudgetExhausted) {
+		t.Errorf("call 3 error = %v, want ErrBudgetExhausted", err)
+	}
+}
+
+func TestErrBudgetExhausted_IsNotRetryable(t *testing.T) {
+	t.Parallel()
+
+	// ErrBudgetExhausted is a plain sentinel → no statusCoder interface →
+	// RetryProvider.isRetryable returns false. Verify by trying to retry it.
+	calls := 0
+	failing := llm.ProviderFunc(func(_ context.Context, _ llm.CompletionRequest) (*llm.CompletionResponse, error) {
+		calls++
+		return nil, llm.ErrBudgetExhausted
+	})
+
+	rp := llm.NewRetryProvider(failing, discardLogger(), llm.WithMaxAttempts(3))
+	rp.SetTimerFn(immediateTimerFn())
+
+	_, err := rp.Complete(context.Background(), llm.CompletionRequest{})
+	if !errors.Is(err, llm.ErrBudgetExhausted) {
+		t.Errorf("error = %v, want ErrBudgetExhausted", err)
+	}
+	if calls != 1 {
+		t.Errorf("calls = %d, want 1 (should not retry budget errors)", calls)
+	}
+}

--- a/internal/llm/provider.go
+++ b/internal/llm/provider.go
@@ -6,3 +6,11 @@ import "context"
 type Provider interface {
 	Complete(ctx context.Context, request CompletionRequest) (*CompletionResponse, error)
 }
+
+// ProviderFunc adapts a plain function to the Provider interface.
+type ProviderFunc func(ctx context.Context, request CompletionRequest) (*CompletionResponse, error)
+
+// Complete delegates to the wrapped function.
+func (f ProviderFunc) Complete(ctx context.Context, request CompletionRequest) (*CompletionResponse, error) {
+	return f(ctx, request)
+}

--- a/internal/llm/provider_chain.go
+++ b/internal/llm/provider_chain.go
@@ -111,7 +111,7 @@ func NewProviderChain(primary Provider, logger *slog.Logger, opts ...ChainOption
 
 	// Layer 1 (innermost): cache
 	if cfg.cache != nil {
-		cp, err := NewCacheProvider(p, cfg.cache, "")
+		cp, err := NewCacheProvider(p, cfg.cache, defaultCacheVersion)
 		if err == nil {
 			if cfg.metrics.cache != nil {
 				cp = cp.WithCacheMetrics(cfg.metrics.cache)

--- a/internal/llm/provider_chain.go
+++ b/internal/llm/provider_chain.go
@@ -1,0 +1,170 @@
+package llm
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// ChainOption configures the provider chain built by NewProviderChain.
+type ChainOption func(*chainConfig)
+
+type chainConfig struct {
+	fallback    Provider
+	maxAttempts int
+	baseDelay   time.Duration
+	throttle    int
+	cache       ResponseCache
+	budget      *Budget
+	callTimeout time.Duration
+	metrics     chainMetrics
+}
+
+type chainMetrics struct {
+	fallback FallbackMetrics
+	cache    CacheMetrics
+}
+
+// WithFallback adds a secondary provider tried when primary fails.
+func WithFallback(p Provider) ChainOption {
+	return func(c *chainConfig) { c.fallback = p }
+}
+
+// WithRetry sets the max retry attempts (including initial call).
+// Values < 1 are ignored.
+func WithRetry(maxAttempts int) ChainOption {
+	return func(c *chainConfig) {
+		if maxAttempts > 0 {
+			c.maxAttempts = maxAttempts
+		}
+	}
+}
+
+// WithRetryBaseDelay sets the base delay for exponential backoff.
+func WithRetryBaseDelay(d time.Duration) ChainOption {
+	return func(c *chainConfig) {
+		if d > 0 {
+			c.baseDelay = d
+		}
+	}
+}
+
+// WithThrottle sets the max concurrent calls. Values < 1 are clamped to 1.
+func WithThrottle(n int) ChainOption {
+	return func(c *chainConfig) { c.throttle = n }
+}
+
+// WithCache enables response caching using the given cache store.
+func WithCache(cache ResponseCache) ChainOption {
+	return func(c *chainConfig) { c.cache = cache }
+}
+
+// WithBudget attaches a budget guard that rejects calls when daily limits are hit.
+func WithBudget(b *Budget) ChainOption {
+	return func(c *chainConfig) { c.budget = b }
+}
+
+// WithCallTimeout wraps each Complete call with a per-call context timeout.
+// Zero or negative values disable per-call timeout.
+func WithCallTimeout(d time.Duration) ChainOption {
+	return func(c *chainConfig) { c.callTimeout = d }
+}
+
+// WithChainFallbackMetrics attaches metrics to the fallback layer.
+func WithChainFallbackMetrics(m FallbackMetrics) ChainOption {
+	return func(c *chainConfig) { c.metrics.fallback = m }
+}
+
+// WithChainCacheMetrics attaches metrics to the cache layer.
+func WithChainCacheMetrics(m CacheMetrics) ChainOption {
+	return func(c *chainConfig) { c.metrics.cache = m }
+}
+
+// NewProviderChain composes a resilient provider from existing primitives.
+//
+// Chain order (outermost → innermost):
+//
+//	budget guard → throttle → retry → fallback → cache → raw provider
+//
+// Each layer is optional; only layers whose options are provided are added.
+// The resulting Provider delegates to the composed chain.
+func NewProviderChain(primary Provider, logger *slog.Logger, opts ...ChainOption) Provider {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	cfg := chainConfig{
+		maxAttempts: 0, // 0 = no retry layer
+		throttle:    0, // 0 = no throttle layer
+	}
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	// Build inside-out: start with primary, wrap outward.
+	var p Provider = primary
+
+	// Layer 1 (innermost): cache
+	if cfg.cache != nil {
+		cp, err := NewCacheProvider(p, cfg.cache, "v1")
+		if err == nil {
+			if cfg.metrics.cache != nil {
+				cp = cp.WithCacheMetrics(cfg.metrics.cache)
+			}
+			p = cp
+		} else {
+			logger.Warn("llm: chain: failed to create cache layer, skipping", slog.Any("error", err))
+		}
+	}
+
+	// Layer 2: fallback
+	if cfg.fallback != nil {
+		fp, err := NewFallbackProvider(p, cfg.fallback, logger)
+		if err == nil {
+			if cfg.metrics.fallback != nil {
+				fp = fp.WithMetrics(cfg.metrics.fallback)
+			}
+			p = fp
+		} else {
+			logger.Warn("llm: chain: failed to create fallback layer, skipping", slog.Any("error", err))
+		}
+	}
+
+	// Layer 3: retry
+	if cfg.maxAttempts > 1 {
+		retryOpts := []RetryOption{WithMaxAttempts(cfg.maxAttempts)}
+		if cfg.baseDelay > 0 {
+			retryOpts = append(retryOpts, WithBaseDelay(cfg.baseDelay))
+		}
+		p = NewRetryProvider(p, logger, retryOpts...)
+	}
+
+	// Layer 4: throttle
+	if cfg.throttle > 0 {
+		p = NewThrottledProvider(p, cfg.throttle)
+	}
+
+	// Layer 5: per-call timeout
+	if cfg.callTimeout > 0 {
+		p = &timeoutProvider{inner: p, timeout: cfg.callTimeout}
+	}
+
+	// Layer 6 (outermost): budget guard
+	if cfg.budget != nil {
+		p = NewBudgetGuardProvider(p, cfg.budget)
+	}
+
+	return p
+}
+
+// timeoutProvider wraps each Complete call with a per-call context timeout.
+type timeoutProvider struct {
+	inner   Provider
+	timeout time.Duration
+}
+
+func (t *timeoutProvider) Complete(ctx context.Context, req CompletionRequest) (*CompletionResponse, error) {
+	ctx, cancel := context.WithTimeout(ctx, t.timeout)
+	defer cancel()
+	return t.inner.Complete(ctx, req)
+}

--- a/internal/llm/provider_chain.go
+++ b/internal/llm/provider_chain.go
@@ -51,7 +51,12 @@ func WithRetryBaseDelay(d time.Duration) ChainOption {
 
 // WithThrottle sets the max concurrent calls. Values < 1 are clamped to 1.
 func WithThrottle(n int) ChainOption {
-	return func(c *chainConfig) { c.throttle = n }
+	return func(c *chainConfig) {
+		if n < 1 {
+			n = 1
+		}
+		c.throttle = n
+	}
 }
 
 // WithCache enables response caching using the given cache store.
@@ -84,7 +89,7 @@ func WithChainCacheMetrics(m CacheMetrics) ChainOption {
 //
 // Chain order (outermost → innermost):
 //
-//	budget guard → throttle → retry → fallback → cache → raw provider
+//	budget guard → timeout → throttle → retry → fallback → cache → raw provider
 //
 // Each layer is optional; only layers whose options are provided are added.
 // The resulting Provider delegates to the composed chain.
@@ -106,7 +111,7 @@ func NewProviderChain(primary Provider, logger *slog.Logger, opts ...ChainOption
 
 	// Layer 1 (innermost): cache
 	if cfg.cache != nil {
-		cp, err := NewCacheProvider(p, cfg.cache, "v1")
+		cp, err := NewCacheProvider(p, cfg.cache, "")
 		if err == nil {
 			if cfg.metrics.cache != nil {
 				cp = cp.WithCacheMetrics(cfg.metrics.cache)

--- a/internal/llm/provider_chain_test.go
+++ b/internal/llm/provider_chain_test.go
@@ -3,6 +3,7 @@ package llm_test
 import (
 	"context"
 	"errors"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -72,6 +73,46 @@ func TestProviderChain_WithThrottle(t *testing.T) {
 	}
 	if got.Content != "throttled" {
 		t.Errorf("content = %q, want %q", got.Content, "throttled")
+	}
+}
+
+func TestProviderChain_WithThrottleClamp(t *testing.T) {
+	t.Parallel()
+
+	var inFlight atomic.Int32
+	var maxInFlight atomic.Int32
+	block := make(chan struct{})
+
+	p := llm.ProviderFunc(func(_ context.Context, _ llm.CompletionRequest) (*llm.CompletionResponse, error) {
+		cur := inFlight.Add(1)
+		for {
+			prev := maxInFlight.Load()
+			if cur <= prev || maxInFlight.CompareAndSwap(prev, cur) {
+				break
+			}
+		}
+		<-block
+		inFlight.Add(-1)
+		return &llm.CompletionResponse{Content: "ok"}, nil
+	})
+
+	chain := llm.NewProviderChain(p, discardLogger(), llm.WithThrottle(0))
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	for range 2 {
+		go func() {
+			defer wg.Done()
+			_, _ = chain.Complete(context.Background(), llm.CompletionRequest{})
+		}()
+	}
+
+	time.Sleep(25 * time.Millisecond)
+	close(block)
+	wg.Wait()
+
+	if maxInFlight.Load() != 1 {
+		t.Errorf("max in-flight = %d, want 1 (throttle should clamp to 1)", maxInFlight.Load())
 	}
 }
 
@@ -220,8 +261,14 @@ func TestProviderChain_BudgetExhaustedNotRetried(t *testing.T) {
 func TestProviderChain_WithCallTimeout(t *testing.T) {
 	t.Parallel()
 
-	// Provider that blocks until context is done.
-	slow := &trackingProvider{err: context.DeadlineExceeded}
+	var sawDeadline atomic.Bool
+	slow := llm.ProviderFunc(func(ctx context.Context, _ llm.CompletionRequest) (*llm.CompletionResponse, error) {
+		if _, ok := ctx.Deadline(); ok {
+			sawDeadline.Store(true)
+		}
+		<-ctx.Done()
+		return nil, ctx.Err()
+	})
 
 	chain := llm.NewProviderChain(slow, discardLogger(),
 		llm.WithCallTimeout(50*time.Millisecond),
@@ -230,6 +277,9 @@ func TestProviderChain_WithCallTimeout(t *testing.T) {
 	_, err := chain.Complete(context.Background(), llm.CompletionRequest{})
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Errorf("error = %v, want DeadlineExceeded", err)
+	}
+	if !sawDeadline.Load() {
+		t.Error("expected provider context to include a deadline")
 	}
 }
 

--- a/internal/llm/provider_chain_test.go
+++ b/internal/llm/provider_chain_test.go
@@ -81,10 +81,14 @@ func TestProviderChain_WithThrottleClamp(t *testing.T) {
 
 	var inFlight atomic.Int32
 	var maxInFlight atomic.Int32
+	start := make(chan struct{})
+	attempting := make(chan struct{}, 2)
+	entered := make(chan struct{}, 2)
 	block := make(chan struct{})
 
 	p := llm.ProviderFunc(func(_ context.Context, _ llm.CompletionRequest) (*llm.CompletionResponse, error) {
 		cur := inFlight.Add(1)
+		entered <- struct{}{}
 		for {
 			prev := maxInFlight.Load()
 			if cur <= prev || maxInFlight.CompareAndSwap(prev, cur) {
@@ -103,12 +107,21 @@ func TestProviderChain_WithThrottleClamp(t *testing.T) {
 	for range 2 {
 		go func() {
 			defer wg.Done()
+			<-start
+			attempting <- struct{}{}
 			_, _ = chain.Complete(context.Background(), llm.CompletionRequest{})
 		}()
 	}
 
-	time.Sleep(25 * time.Millisecond)
+	close(start)
+	<-attempting
+	<-attempting
+	<-entered
+	if inFlight.Load() != 1 {
+		t.Fatalf("in-flight before release = %d, want 1", inFlight.Load())
+	}
 	close(block)
+	<-entered
 	wg.Wait()
 
 	if maxInFlight.Load() != 1 {

--- a/internal/llm/provider_chain_test.go
+++ b/internal/llm/provider_chain_test.go
@@ -1,0 +1,300 @@
+package llm_test
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/PatrickFanella/get-rich-quick/internal/llm"
+)
+
+// --- helpers ---
+
+// trackingProvider records call count + last request, returns canned response.
+type trackingProvider struct {
+	response *llm.CompletionResponse
+	err      error
+	calls    atomic.Int32
+}
+
+func (p *trackingProvider) Complete(_ context.Context, _ llm.CompletionRequest) (*llm.CompletionResponse, error) {
+	p.calls.Add(1)
+	return p.response, p.err
+}
+
+type stubFallbackMetrics struct{ reasons []string }
+
+func (s *stubFallbackMetrics) RecordLLMFallback(reason string) { s.reasons = append(s.reasons, reason) }
+
+type stubCacheMetrics struct {
+	hits   atomic.Int32
+	misses atomic.Int32
+}
+
+func (s *stubCacheMetrics) RecordLLMCacheHit()  { s.hits.Add(1) }
+func (s *stubCacheMetrics) RecordLLMCacheMiss() { s.misses.Add(1) }
+
+// --- NewProviderChain tests ---
+
+func TestProviderChain_PrimaryOnly(t *testing.T) {
+	t.Parallel()
+
+	want := &llm.CompletionResponse{Content: "ok", Usage: llm.CompletionUsage{PromptTokens: 5, CompletionTokens: 3}}
+	p := &trackingProvider{response: want}
+
+	chain := llm.NewProviderChain(p, discardLogger())
+
+	got, err := chain.Complete(context.Background(), llm.CompletionRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Content != "ok" {
+		t.Errorf("content = %q, want %q", got.Content, "ok")
+	}
+	if p.calls.Load() != 1 {
+		t.Errorf("calls = %d, want 1", p.calls.Load())
+	}
+}
+
+func TestProviderChain_WithThrottle(t *testing.T) {
+	t.Parallel()
+
+	want := &llm.CompletionResponse{Content: "throttled"}
+	p := &trackingProvider{response: want}
+
+	chain := llm.NewProviderChain(p, discardLogger(), llm.WithThrottle(2))
+
+	got, err := chain.Complete(context.Background(), llm.CompletionRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Content != "throttled" {
+		t.Errorf("content = %q, want %q", got.Content, "throttled")
+	}
+}
+
+func TestProviderChain_WithCache(t *testing.T) {
+	t.Parallel()
+
+	want := &llm.CompletionResponse{Content: "cached", Usage: llm.CompletionUsage{PromptTokens: 1}}
+	p := &trackingProvider{response: want}
+	cache := llm.NewMemoryResponseCache()
+	cm := &stubCacheMetrics{}
+
+	chain := llm.NewProviderChain(p, discardLogger(),
+		llm.WithCache(cache),
+		llm.WithChainCacheMetrics(cm),
+	)
+
+	req := llm.CompletionRequest{Model: "test", Messages: []llm.Message{{Role: "user", Content: "hello"}}}
+
+	// First call: miss
+	got, err := chain.Complete(context.Background(), req)
+	if err != nil {
+		t.Fatalf("call 1: %v", err)
+	}
+	if got.Content != "cached" {
+		t.Errorf("call 1 content = %q, want %q", got.Content, "cached")
+	}
+
+	// Second call: hit (provider not called again)
+	got2, err := chain.Complete(context.Background(), req)
+	if err != nil {
+		t.Fatalf("call 2: %v", err)
+	}
+	if got2.Content != "cached" {
+		t.Errorf("call 2 content = %q, want %q", got2.Content, "cached")
+	}
+	if p.calls.Load() != 1 {
+		t.Errorf("provider calls = %d, want 1 (cache should serve second)", p.calls.Load())
+	}
+	if cm.hits.Load() < 1 {
+		t.Errorf("cache hits = %d, want ≥1", cm.hits.Load())
+	}
+}
+
+func TestProviderChain_WithFallback(t *testing.T) {
+	t.Parallel()
+
+	primary := &trackingProvider{err: errors.New("primary down")}
+	secondary := &trackingProvider{response: &llm.CompletionResponse{Content: "fallback"}}
+
+	chain := llm.NewProviderChain(primary, discardLogger(), llm.WithFallback(secondary))
+
+	got, err := chain.Complete(context.Background(), llm.CompletionRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Content != "fallback" {
+		t.Errorf("content = %q, want %q", got.Content, "fallback")
+	}
+	if secondary.calls.Load() != 1 {
+		t.Errorf("secondary calls = %d, want 1", secondary.calls.Load())
+	}
+}
+
+func TestProviderChain_WithRetry(t *testing.T) {
+	t.Parallel()
+
+	// Fail once with 429, succeed on retry
+	calls := &atomic.Int32{}
+	retryable := &httpError{code: 429, msg: "rate limited"}
+	want := &llm.CompletionResponse{Content: "retried", Usage: llm.CompletionUsage{PromptTokens: 2}}
+
+	mock := newMockProvider(
+		[]*llm.CompletionResponse{nil, want},
+		[]error{retryable, nil},
+	)
+	calls = &mock.calls
+
+	chain := llm.NewProviderChain(mock, discardLogger(),
+		llm.WithRetry(3),
+		llm.WithRetryBaseDelay(1*time.Millisecond),
+	)
+
+	got, err := chain.Complete(context.Background(), llm.CompletionRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Content != "retried" {
+		t.Errorf("content = %q, want %q", got.Content, "retried")
+	}
+	if calls.Load() != 2 {
+		t.Errorf("calls = %d, want 2", calls.Load())
+	}
+}
+
+func TestProviderChain_WithBudgetExhausted(t *testing.T) {
+	t.Parallel()
+
+	p := &trackingProvider{response: &llm.CompletionResponse{Content: "should not reach"}}
+	budget := llm.NewBudget(1, 0) // 1 request max
+
+	chain := llm.NewProviderChain(p, discardLogger(), llm.WithBudget(budget))
+
+	// First call succeeds, uses up budget
+	_, err := chain.Complete(context.Background(), llm.CompletionRequest{})
+	if err != nil {
+		t.Fatalf("call 1: %v", err)
+	}
+
+	// Second call rejected
+	_, err = chain.Complete(context.Background(), llm.CompletionRequest{})
+	if !errors.Is(err, llm.ErrBudgetExhausted) {
+		t.Errorf("call 2 error = %v, want ErrBudgetExhausted", err)
+	}
+	if p.calls.Load() != 1 {
+		t.Errorf("provider calls = %d, want 1 (budget should block second)", p.calls.Load())
+	}
+}
+
+func TestProviderChain_BudgetExhaustedNotRetried(t *testing.T) {
+	t.Parallel()
+
+	p := &trackingProvider{response: &llm.CompletionResponse{Content: "ok"}}
+	budget := llm.NewBudget(1, 0)
+
+	// Chain with retry + budget. Budget is outermost, so exhaustion bypasses retry.
+	chain := llm.NewProviderChain(p, discardLogger(),
+		llm.WithRetry(3),
+		llm.WithRetryBaseDelay(1*time.Millisecond),
+		llm.WithBudget(budget),
+	)
+
+	// Exhaust budget
+	_, _ = chain.Complete(context.Background(), llm.CompletionRequest{})
+
+	// Next call: budget error, not retried
+	_, err := chain.Complete(context.Background(), llm.CompletionRequest{})
+	if !errors.Is(err, llm.ErrBudgetExhausted) {
+		t.Errorf("error = %v, want ErrBudgetExhausted", err)
+	}
+	// Provider should only have been called once (the first success)
+	if p.calls.Load() != 1 {
+		t.Errorf("provider calls = %d, want 1", p.calls.Load())
+	}
+}
+
+func TestProviderChain_WithCallTimeout(t *testing.T) {
+	t.Parallel()
+
+	// Provider that blocks until context is done.
+	slow := &trackingProvider{err: context.DeadlineExceeded}
+
+	chain := llm.NewProviderChain(slow, discardLogger(),
+		llm.WithCallTimeout(50*time.Millisecond),
+	)
+
+	_, err := chain.Complete(context.Background(), llm.CompletionRequest{})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("error = %v, want DeadlineExceeded", err)
+	}
+}
+
+func TestProviderChain_FullStack(t *testing.T) {
+	t.Parallel()
+
+	// Full chain: budget → timeout → throttle → retry → fallback → cache → primary
+	primary := &trackingProvider{
+		response: &llm.CompletionResponse{
+			Content: "full-stack",
+			Usage:   llm.CompletionUsage{PromptTokens: 10, CompletionTokens: 5},
+		},
+	}
+	secondary := &trackingProvider{response: &llm.CompletionResponse{Content: "backup"}}
+	cache := llm.NewMemoryResponseCache()
+	budget := llm.NewBudget(100, 0)
+
+	chain := llm.NewProviderChain(primary, discardLogger(),
+		llm.WithThrottle(4),
+		llm.WithRetry(2),
+		llm.WithRetryBaseDelay(1*time.Millisecond),
+		llm.WithFallback(secondary),
+		llm.WithCache(cache),
+		llm.WithBudget(budget),
+		llm.WithCallTimeout(5*time.Second),
+	)
+
+	got, err := chain.Complete(context.Background(), llm.CompletionRequest{
+		Model:    "test",
+		Messages: []llm.Message{{Role: "user", Content: "full test"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Content != "full-stack" {
+		t.Errorf("content = %q, want %q", got.Content, "full-stack")
+	}
+
+	stats := budget.Stats()
+	if stats.Requests != 1 {
+		t.Errorf("budget requests = %d, want 1", stats.Requests)
+	}
+}
+
+func TestProviderChain_SubsetOptions(t *testing.T) {
+	t.Parallel()
+
+	// Only throttle + cache, no retry/fallback/budget/timeout
+	p := &trackingProvider{
+		response: &llm.CompletionResponse{Content: "subset"},
+	}
+
+	chain := llm.NewProviderChain(p, discardLogger(),
+		llm.WithThrottle(2),
+		llm.WithCache(llm.NewMemoryResponseCache()),
+	)
+
+	got, err := chain.Complete(context.Background(), llm.CompletionRequest{
+		Model:    "m",
+		Messages: []llm.Message{{Role: "user", Content: "x"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Content != "subset" {
+		t.Errorf("content = %q, want %q", got.Content, "subset")
+	}
+}


### PR DESCRIPTION
## Summary

PR 1 of [LLM Resilience Refactor Plan](docs/design/llm-resilience-refactor-plan.md). Pure library code — zero runtime changes. Safe to merge independently.

## What

**`NewProviderChain`** — builder that composes existing LLM primitives into a single resilient `Provider`:

```
budget guard → timeout → throttle → retry → fallback → cache → raw provider
```

Each layer is optional, controlled via option funcs:
- `WithFallback(Provider)` — secondary provider on failure
- `WithRetry(maxAttempts)` / `WithRetryBaseDelay(d)` — exponential backoff on 429/5xx
- `WithThrottle(n)` — concurrency semaphore
- `WithCache(ResponseCache)` — response dedup
- `WithBudget(*Budget)` — daily request/token guard
- `WithCallTimeout(d)` — per-call context deadline
- `WithChainFallbackMetrics` / `WithChainCacheMetrics` — observability hooks

**`Budget`** — thread-safe daily usage tracker:
- `Allow()` / `Record(prompt, completion)` / `Reset()` / `Stats()`
- Auto-resets at UTC midnight
- `ErrBudgetExhausted` sentinel (not retryable by `RetryProvider`)

**`BudgetGuardProvider`** — wraps `Provider`, rejects when budget exhausted, records usage on success.

**`ProviderFunc`** — adapter: plain function → `Provider` interface.

## Files Changed

| File | Change |
|------|--------|
| `internal/llm/provider_chain.go` | New: chain builder + `timeoutProvider` |
| `internal/llm/budget.go` | New: `Budget`, `BudgetGuardProvider`, `ErrBudgetExhausted` |
| `internal/llm/provider_chain_test.go` | 9 tests: each layer + full-stack combo |
| `internal/llm/budget_test.go` | 7 tests: limits, reset, stats, guard, non-retryability |
| `internal/llm/provider.go` | Added `ProviderFunc` type |

## Testing

- `go test -short -count=1 ./internal/llm/...` — all pass
- `go build ./cmd/tradingagent` — clean (no runtime imports changed)