### PR TITLE
feat(db): report_artifacts table and repo (PR 4)

### DIFF
--- a/cmd/tradingagent/runtime_test.go
+++ b/cmd/tradingagent/runtime_test.go
@@ -70,7 +70,7 @@ func TestNewAPIServerSchemaBehindFailsFast(t *testing.T) {
 	if mismatchErr.Required != pgrepo.RequiredSchemaVersion {
 		t.Fatalf("mismatchErr.Required = %d, want %d", mismatchErr.Required, pgrepo.RequiredSchemaVersion)
 	}
-	for _, want := range []string{"current version 27", "required version 28", "run migrations, then restart the process", "fresh process restart"} {
+	for _, want := range []string{"current version 28", "required version 29", "run migrations, then restart the process", "fresh process restart"} {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("error %q missing %q", err.Error(), want)
 		}
@@ -125,7 +125,7 @@ func TestNewAPIServerSchemaAheadFailsFast(t *testing.T) {
 	if mismatchErr.Required != pgrepo.RequiredSchemaVersion {
 		t.Fatalf("mismatchErr.Required = %d, want %d", mismatchErr.Required, pgrepo.RequiredSchemaVersion)
 	}
-	for _, want := range []string{"current version 29", "required version 28", "run migrations, then restart the process", "fresh process restart"} {
+	for _, want := range []string{"current version 30", "required version 29", "run migrations, then restart the process", "fresh process restart"} {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("error %q missing %q", err.Error(), want)
 		}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -207,46 +207,6 @@ func validateLLMProviderSelection(rawProvider, envName string, llmCfg LLMConfig)
 	return ""
 }
 
-// validateFallbackProvider checks that LLM_FALLBACK_PROVIDER (when set) names a
-// known provider and that the corresponding API key is present.
-func validateFallbackProvider(llmCfg LLMConfig) string {
-	provider := strings.TrimSpace(strings.ToLower(llmCfg.FallbackProvider))
-	if provider == "" {
-		return ""
-	}
-
-	known := []string{"openai", "anthropic", "google", "openrouter", "xai", "ollama"}
-	if !slices.Contains(known, provider) {
-		return fmt.Sprintf("LLM_FALLBACK_PROVIDER %q is not a known provider", llmCfg.FallbackProvider)
-	}
-
-	switch provider {
-	case "openai":
-		if strings.TrimSpace(llmCfg.Providers.OpenAI.APIKey) == "" {
-			return "LLM_FALLBACK_PROVIDER is openai but OPENAI_API_KEY is not set"
-		}
-	case "anthropic":
-		if strings.TrimSpace(llmCfg.Providers.Anthropic.APIKey) == "" {
-			return "LLM_FALLBACK_PROVIDER is anthropic but ANTHROPIC_API_KEY is not set"
-		}
-	case "google":
-		if strings.TrimSpace(llmCfg.Providers.Google.APIKey) == "" {
-			return "LLM_FALLBACK_PROVIDER is google but GOOGLE_API_KEY is not set"
-		}
-	case "openrouter":
-		if strings.TrimSpace(llmCfg.Providers.OpenRouter.APIKey) == "" {
-			return "LLM_FALLBACK_PROVIDER is openrouter but OPENROUTER_API_KEY is not set"
-		}
-	case "xai":
-		if strings.TrimSpace(llmCfg.Providers.XAI.APIKey) == "" {
-			return "LLM_FALLBACK_PROVIDER is xai but XAI_API_KEY is not set"
-		}
-	case "ollama":
-		// Ollama doesn't require an API key.
-	}
-	return ""
-}
-
 func validateBrokerCredentials(errs *[]string, keyName, keyValue, secretName, secretValue string) {
 	hasKey := strings.TrimSpace(keyValue) != ""
 	hasSecret := strings.TrimSpace(secretValue) != ""

--- a/internal/repository/postgres/report_artifact.go
+++ b/internal/repository/postgres/report_artifact.go
@@ -3,10 +3,12 @@ package postgres
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -62,7 +64,10 @@ func (r *ReportArtifactRepo) Upsert(ctx context.Context, a *ReportArtifact) erro
 	}
 
 	var reportJSON []byte
-	if len(a.ReportJSON) > 0 && json.Valid(a.ReportJSON) {
+	if len(a.ReportJSON) > 0 {
+		if !json.Valid(a.ReportJSON) {
+			return fmt.Errorf("postgres: report artifact report_json must be valid JSON")
+		}
 		reportJSON = a.ReportJSON
 	}
 
@@ -107,14 +112,15 @@ FROM report_artifacts
 WHERE strategy_id = $1
   AND report_type = $2
   AND status = 'completed'
-ORDER BY completed_at DESC
+  AND completed_at IS NOT NULL
+ORDER BY completed_at DESC NULLS LAST, created_at DESC, id DESC
 LIMIT 1`,
 		strategyID, reportType,
 	)
 
 	a, err := scanReportArtifact(row)
 	if err != nil {
-		if isNoRows(err) {
+		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("postgres: get latest report artifact: %w", err)
@@ -195,7 +201,6 @@ func (r *ReportArtifactRepo) Count(ctx context.Context, filter ReportArtifactFil
 		args = append(args, filter.Status)
 		argN++
 	}
-	_ = argN
 
 	var count int
 	if err := r.pool.QueryRow(ctx, query, args...).Scan(&count); err != nil {
@@ -206,18 +211,21 @@ func (r *ReportArtifactRepo) Count(ctx context.Context, filter ReportArtifactFil
 
 func scanReportArtifact(s scanner) (*ReportArtifact, error) {
 	var (
-		a            ReportArtifact
-		reportJSON   []byte
-		provider     *string
-		model        *string
-		errMsg       *string
-		completedAt  *time.Time
+		a                ReportArtifact
+		reportJSON       []byte
+		provider         *string
+		model            *string
+		errMsg           *string
+		promptTokens     *int
+		completionTokens *int
+		latencyMs        *int
+		completedAt      *time.Time
 	)
 
 	if err := s.Scan(
 		&a.ID, &a.StrategyID, &a.ReportType, &a.TimeBucket, &a.Status,
 		&reportJSON, &provider, &model,
-		&a.PromptTokens, &a.CompletionTokens, &a.LatencyMs,
+		&promptTokens, &completionTokens, &latencyMs,
 		&errMsg, &a.CreatedAt, &completedAt,
 	); err != nil {
 		return nil, err
@@ -235,12 +243,16 @@ func scanReportArtifact(s scanner) (*ReportArtifact, error) {
 	if errMsg != nil {
 		a.ErrorMessage = *errMsg
 	}
+	if promptTokens != nil {
+		a.PromptTokens = *promptTokens
+	}
+	if completionTokens != nil {
+		a.CompletionTokens = *completionTokens
+	}
+	if latencyMs != nil {
+		a.LatencyMs = *latencyMs
+	}
 	a.CompletedAt = completedAt
 
 	return &a, nil
-}
-
-// isNoRows reports whether err signals a "no rows" result from pgx.
-func isNoRows(err error) bool {
-	return err.Error() == "no rows in result set"
 }

--- a/internal/repository/postgres/report_artifact.go
+++ b/internal/repository/postgres/report_artifact.go
@@ -1,0 +1,246 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// ReportArtifact represents a single LLM-generated report persisted to the
+// report_artifacts table. The idempotency key is (strategy_id, report_type,
+// time_bucket); upserts on the same key update in place.
+type ReportArtifact struct {
+	ID               uuid.UUID       `json:"id"`
+	StrategyID       uuid.UUID       `json:"strategy_id"`
+	ReportType       string          `json:"report_type"`
+	TimeBucket       time.Time       `json:"time_bucket"`
+	Status           string          `json:"status"`
+	ReportJSON       json.RawMessage `json:"report_json,omitempty"`
+	Provider         string          `json:"provider,omitempty"`
+	Model            string          `json:"model,omitempty"`
+	PromptTokens     int             `json:"prompt_tokens"`
+	CompletionTokens int             `json:"completion_tokens"`
+	LatencyMs        int             `json:"latency_ms"`
+	ErrorMessage     string          `json:"error_message,omitempty"`
+	CreatedAt        time.Time       `json:"created_at"`
+	CompletedAt      *time.Time      `json:"completed_at,omitempty"`
+}
+
+// ReportArtifactFilter defines supported filters when listing report artifacts.
+type ReportArtifactFilter struct {
+	StrategyID *uuid.UUID
+	ReportType string
+	Status     string
+}
+
+// ReportArtifactRepo persists LLM-generated report artifacts to PostgreSQL.
+type ReportArtifactRepo struct {
+	pool *pgxpool.Pool
+}
+
+// NewReportArtifactRepo returns a new ReportArtifactRepo.
+func NewReportArtifactRepo(pool *pgxpool.Pool) *ReportArtifactRepo {
+	return &ReportArtifactRepo{pool: pool}
+}
+
+// Upsert inserts or updates a report artifact using the idempotency key
+// (strategy_id, report_type, time_bucket). On conflict all mutable fields
+// are overwritten. ID and CreatedAt are populated on insert.
+func (r *ReportArtifactRepo) Upsert(ctx context.Context, a *ReportArtifact) error {
+	if a.StrategyID == uuid.Nil {
+		return fmt.Errorf("postgres: report artifact strategy_id is required")
+	}
+	if a.ReportType == "" {
+		a.ReportType = "paper_validation"
+	}
+	if a.Status == "" {
+		a.Status = "pending"
+	}
+
+	var reportJSON []byte
+	if len(a.ReportJSON) > 0 && json.Valid(a.ReportJSON) {
+		reportJSON = a.ReportJSON
+	}
+
+	row := r.pool.QueryRow(ctx, `
+INSERT INTO report_artifacts
+    (strategy_id, report_type, time_bucket, status, report_json,
+     provider, model, prompt_tokens, completion_tokens, latency_ms,
+     error_message, completed_at)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+ON CONFLICT (strategy_id, report_type, time_bucket) DO UPDATE SET
+    status            = EXCLUDED.status,
+    report_json       = EXCLUDED.report_json,
+    provider          = EXCLUDED.provider,
+    model             = EXCLUDED.model,
+    prompt_tokens     = EXCLUDED.prompt_tokens,
+    completion_tokens = EXCLUDED.completion_tokens,
+    latency_ms        = EXCLUDED.latency_ms,
+    error_message     = EXCLUDED.error_message,
+    completed_at      = EXCLUDED.completed_at
+RETURNING id, created_at`,
+		a.StrategyID, a.ReportType, a.TimeBucket, a.Status, reportJSON,
+		nullString(a.Provider), nullString(a.Model),
+		a.PromptTokens, a.CompletionTokens, a.LatencyMs,
+		nullString(a.ErrorMessage), a.CompletedAt,
+	)
+
+	return row.Scan(&a.ID, &a.CreatedAt)
+}
+
+// GetLatest returns the most recently completed report artifact for the given
+// strategy and report type. Returns (nil, nil) when no completed artifact exists.
+func (r *ReportArtifactRepo) GetLatest(ctx context.Context, strategyID uuid.UUID, reportType string) (*ReportArtifact, error) {
+	if reportType == "" {
+		reportType = "paper_validation"
+	}
+
+	row := r.pool.QueryRow(ctx, `
+SELECT id, strategy_id, report_type, time_bucket, status, report_json,
+       provider, model, prompt_tokens, completion_tokens, latency_ms,
+       error_message, created_at, completed_at
+FROM report_artifacts
+WHERE strategy_id = $1
+  AND report_type = $2
+  AND status = 'completed'
+ORDER BY completed_at DESC
+LIMIT 1`,
+		strategyID, reportType,
+	)
+
+	a, err := scanReportArtifact(row)
+	if err != nil {
+		if isNoRows(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("postgres: get latest report artifact: %w", err)
+	}
+	return a, nil
+}
+
+// List returns report artifacts matching the filter, newest first.
+func (r *ReportArtifactRepo) List(ctx context.Context, filter ReportArtifactFilter, limit, offset int) ([]ReportArtifact, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+
+	query := `
+SELECT id, strategy_id, report_type, time_bucket, status, report_json,
+       provider, model, prompt_tokens, completion_tokens, latency_ms,
+       error_message, created_at, completed_at
+FROM report_artifacts
+WHERE 1=1`
+
+	args := []any{}
+	argN := 1
+
+	if filter.StrategyID != nil {
+		query += fmt.Sprintf(" AND strategy_id = $%d", argN)
+		args = append(args, *filter.StrategyID)
+		argN++
+	}
+	if filter.ReportType != "" {
+		query += fmt.Sprintf(" AND report_type = $%d", argN)
+		args = append(args, filter.ReportType)
+		argN++
+	}
+	if filter.Status != "" {
+		query += fmt.Sprintf(" AND status = $%d", argN)
+		args = append(args, filter.Status)
+		argN++
+	}
+
+	query += fmt.Sprintf(" ORDER BY created_at DESC LIMIT $%d OFFSET $%d", argN, argN+1)
+	args = append(args, limit, offset)
+
+	rows, err := r.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("postgres: list report artifacts: %w", err)
+	}
+	defer rows.Close()
+
+	var artifacts []ReportArtifact
+	for rows.Next() {
+		a, err := scanReportArtifact(rows)
+		if err != nil {
+			return nil, fmt.Errorf("postgres: scan report artifact: %w", err)
+		}
+		artifacts = append(artifacts, *a)
+	}
+	return artifacts, rows.Err()
+}
+
+// Count returns the number of report artifacts matching the filter.
+func (r *ReportArtifactRepo) Count(ctx context.Context, filter ReportArtifactFilter) (int, error) {
+	query := `SELECT COUNT(*) FROM report_artifacts WHERE 1=1`
+	args := []any{}
+	argN := 1
+
+	if filter.StrategyID != nil {
+		query += fmt.Sprintf(" AND strategy_id = $%d", argN)
+		args = append(args, *filter.StrategyID)
+		argN++
+	}
+	if filter.ReportType != "" {
+		query += fmt.Sprintf(" AND report_type = $%d", argN)
+		args = append(args, filter.ReportType)
+		argN++
+	}
+	if filter.Status != "" {
+		query += fmt.Sprintf(" AND status = $%d", argN)
+		args = append(args, filter.Status)
+		argN++
+	}
+	_ = argN
+
+	var count int
+	if err := r.pool.QueryRow(ctx, query, args...).Scan(&count); err != nil {
+		return 0, fmt.Errorf("postgres: count report artifacts: %w", err)
+	}
+	return count, nil
+}
+
+func scanReportArtifact(s scanner) (*ReportArtifact, error) {
+	var (
+		a            ReportArtifact
+		reportJSON   []byte
+		provider     *string
+		model        *string
+		errMsg       *string
+		completedAt  *time.Time
+	)
+
+	if err := s.Scan(
+		&a.ID, &a.StrategyID, &a.ReportType, &a.TimeBucket, &a.Status,
+		&reportJSON, &provider, &model,
+		&a.PromptTokens, &a.CompletionTokens, &a.LatencyMs,
+		&errMsg, &a.CreatedAt, &completedAt,
+	); err != nil {
+		return nil, err
+	}
+
+	if len(reportJSON) > 0 {
+		a.ReportJSON = json.RawMessage(reportJSON)
+	}
+	if provider != nil {
+		a.Provider = *provider
+	}
+	if model != nil {
+		a.Model = *model
+	}
+	if errMsg != nil {
+		a.ErrorMessage = *errMsg
+	}
+	a.CompletedAt = completedAt
+
+	return &a, nil
+}
+
+// isNoRows reports whether err signals a "no rows" result from pgx.
+func isNoRows(err error) bool {
+	return err.Error() == "no rows in result set"
+}

--- a/internal/repository/postgres/report_artifact_test.go
+++ b/internal/repository/postgres/report_artifact_test.go
@@ -161,17 +161,17 @@ func TestReportArtifactRepo_UpsertIdempotency(t *testing.T) {
 
 	// Second upsert on same key — updates to completed.
 	a2 := &ReportArtifact{
-		StrategyID:  strategyID,
-		ReportType:  "paper_validation",
-		TimeBucket:  timeBucket,
-		Status:      "completed",
-		ReportJSON:  json.RawMessage(`{"score":0.92}`),
-		Provider:    "openai",
-		Model:       "gpt-5-mini",
-		PromptTokens: 100,
+		StrategyID:       strategyID,
+		ReportType:       "paper_validation",
+		TimeBucket:       timeBucket,
+		Status:           "completed",
+		ReportJSON:       json.RawMessage(`{"score":0.92}`),
+		Provider:         "openai",
+		Model:            "gpt-5-mini",
+		PromptTokens:     100,
 		CompletionTokens: 200,
-		LatencyMs:   450,
-		CompletedAt: &completedAt,
+		LatencyMs:        450,
+		CompletedAt:      &completedAt,
 	}
 	if err := repo.Upsert(ctx, a2); err != nil {
 		t.Fatalf("second Upsert() error = %v", err)
@@ -263,6 +263,33 @@ func TestReportArtifactRepo_GetLatestNilWhenNone(t *testing.T) {
 	}
 }
 
+func TestReportArtifactRepo_GetLatestIgnoresCompletedWithNullCompletedAt(t *testing.T) {
+	ctx := context.Background()
+	pool, cleanup := newReportArtifactIntegrationPool(t, ctx)
+	defer cleanup()
+
+	strategyID := seedReportArtifactStrategy(t, ctx, pool)
+	repo := NewReportArtifactRepo(pool)
+
+	timeBucket := time.Date(2026, 4, 16, 17, 0, 0, 0, time.UTC)
+	if _, err := pool.Exec(ctx, `
+INSERT INTO report_artifacts
+  (strategy_id, report_type, time_bucket, status, completed_at)
+VALUES
+  ($1, 'paper_validation', $2, 'completed', NULL)
+`, strategyID, timeBucket); err != nil {
+		t.Fatalf("failed to seed row: %v", err)
+	}
+
+	got, err := repo.GetLatest(ctx, strategyID, "paper_validation")
+	if err != nil {
+		t.Fatalf("GetLatest() error = %v", err)
+	}
+	if got != nil {
+		t.Fatalf("GetLatest() = %+v, want nil when completed_at is NULL", got)
+	}
+}
+
 func TestReportArtifactRepo_List(t *testing.T) {
 	ctx := context.Background()
 	pool, cleanup := newReportArtifactIntegrationPool(t, ctx)
@@ -327,6 +354,55 @@ func TestReportArtifactRepo_UpsertRequiresStrategyID(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "strategy_id is required") {
 		t.Fatalf("error %q missing 'strategy_id is required'", err.Error())
+	}
+}
+
+func TestReportArtifactRepo_UpsertRejectsInvalidReportJSON(t *testing.T) {
+	t.Parallel()
+
+	repo := NewReportArtifactRepo(nil) // pool unused; validation happens before query
+	err := repo.Upsert(context.Background(), &ReportArtifact{
+		StrategyID: uuid.New(),
+		TimeBucket: time.Now(),
+		Status:     "pending",
+		ReportJSON: json.RawMessage(`{"score":`),
+	})
+	if err == nil {
+		t.Fatal("Upsert() error = nil, want invalid JSON validation error")
+	}
+	if !strings.Contains(err.Error(), "report_json must be valid JSON") {
+		t.Fatalf("error %q missing invalid report_json validation message", err.Error())
+	}
+}
+
+func TestReportArtifactRepo_GetLatestWithNullNumericFields(t *testing.T) {
+	ctx := context.Background()
+	pool, cleanup := newReportArtifactIntegrationPool(t, ctx)
+	defer cleanup()
+
+	strategyID := seedReportArtifactStrategy(t, ctx, pool)
+	repo := NewReportArtifactRepo(pool)
+
+	completedAt := time.Date(2026, 4, 16, 17, 1, 0, 0, time.UTC)
+	timeBucket := time.Date(2026, 4, 16, 17, 0, 0, 0, time.UTC)
+	if _, err := pool.Exec(ctx, `
+INSERT INTO report_artifacts
+  (strategy_id, report_type, time_bucket, status, prompt_tokens, completion_tokens, latency_ms, completed_at)
+VALUES
+  ($1, 'paper_validation', $2, 'completed', NULL, NULL, NULL, $3)
+`, strategyID, timeBucket, completedAt); err != nil {
+		t.Fatalf("failed to seed report_artifacts row with null numeric fields: %v", err)
+	}
+
+	got, err := repo.GetLatest(ctx, strategyID, "paper_validation")
+	if err != nil {
+		t.Fatalf("GetLatest() error = %v", err)
+	}
+	if got == nil {
+		t.Fatal("GetLatest() = nil, want artifact")
+	}
+	if got.PromptTokens != 0 || got.CompletionTokens != 0 || got.LatencyMs != 0 {
+		t.Fatalf("expected null numeric fields to map to zero values, got prompt=%d completion=%d latency=%d", got.PromptTokens, got.CompletionTokens, got.LatencyMs)
 	}
 }
 

--- a/internal/repository/postgres/report_artifact_test.go
+++ b/internal/repository/postgres/report_artifact_test.go
@@ -1,0 +1,343 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// newReportArtifactIntegrationPool creates an isolated schema with the full
+// table DDL needed to exercise ReportArtifactRepo. Skips when short or no DB_URL.
+func newReportArtifactIntegrationPool(t *testing.T, ctx context.Context) (*pgxpool.Pool, func()) {
+	t.Helper()
+
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	connString := os.Getenv("DB_URL")
+	if connString == "" {
+		connString = os.Getenv("DATABASE_URL")
+	}
+	if connString == "" {
+		t.Skip("skipping integration test: DB_URL or DATABASE_URL is not set")
+	}
+
+	adminPool, err := pgxpool.New(ctx, connString)
+	if err != nil {
+		t.Fatalf("failed to create admin pool: %v", err)
+	}
+
+	if _, err := adminPool.Exec(ctx, `CREATE EXTENSION IF NOT EXISTS pgcrypto`); err != nil {
+		adminPool.Close()
+		t.Fatalf("failed to ensure pgcrypto extension: %v", err)
+	}
+
+	schemaName := "integration_report_artifact_" + strings.ReplaceAll(uuid.New().String(), "-", "")
+	sanitizedSchemaName := pgx.Identifier{schemaName}.Sanitize()
+	if _, err := adminPool.Exec(ctx, `CREATE SCHEMA `+sanitizedSchemaName); err != nil {
+		adminPool.Close()
+		t.Fatalf("failed to create test schema: %v", err)
+	}
+
+	config, err := pgxpool.ParseConfig(connString)
+	if err != nil {
+		_, _ = adminPool.Exec(ctx, `DROP SCHEMA `+sanitizedSchemaName+` CASCADE`)
+		adminPool.Close()
+		t.Fatalf("failed to parse pool config: %v", err)
+	}
+	config.ConnConfig.RuntimeParams["search_path"] = schemaName + ",public"
+
+	pool, err := pgxpool.NewWithConfig(ctx, config)
+	if err != nil {
+		_, _ = adminPool.Exec(ctx, `DROP SCHEMA `+sanitizedSchemaName+` CASCADE`)
+		adminPool.Close()
+		t.Fatalf("failed to create test pool: %v", err)
+	}
+
+	// Minimal DDL: strategies table + report_artifacts table (no full migration stack).
+	for _, stmt := range []string{
+		`CREATE EXTENSION IF NOT EXISTS pgcrypto`,
+		`CREATE TABLE strategies (
+			id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+			name        TEXT        NOT NULL,
+			ticker      TEXT        NOT NULL,
+			market_type TEXT        NOT NULL DEFAULT 'stock',
+			is_active   BOOLEAN     NOT NULL DEFAULT TRUE
+		)`,
+		`CREATE TABLE report_artifacts (
+			id                UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+			strategy_id       UUID        NOT NULL REFERENCES strategies(id),
+			report_type       TEXT        NOT NULL DEFAULT 'paper_validation',
+			time_bucket       TIMESTAMPTZ NOT NULL,
+			status            TEXT        NOT NULL DEFAULT 'pending',
+			report_json       JSONB,
+			provider          TEXT,
+			model             TEXT,
+			prompt_tokens     INT         DEFAULT 0,
+			completion_tokens INT         DEFAULT 0,
+			latency_ms        INT         DEFAULT 0,
+			error_message     TEXT,
+			created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+			completed_at      TIMESTAMPTZ,
+			UNIQUE (strategy_id, report_type, time_bucket)
+		)`,
+		`CREATE INDEX idx_report_artifacts_strategy_type
+			ON report_artifacts (strategy_id, report_type, completed_at DESC)`,
+	} {
+		if _, err := pool.Exec(ctx, stmt); err != nil {
+			pool.Close()
+			_, _ = adminPool.Exec(ctx, `DROP SCHEMA `+sanitizedSchemaName+` CASCADE`)
+			adminPool.Close()
+			t.Fatalf("failed to apply DDL: %v", err)
+		}
+	}
+
+	cleanup := func() {
+		pool.Close()
+		_, _ = adminPool.Exec(ctx, `DROP SCHEMA `+sanitizedSchemaName+` CASCADE`)
+		adminPool.Close()
+	}
+
+	return pool, cleanup
+}
+
+func TestReportArtifactRepo_UpsertInserts(t *testing.T) {
+	ctx := context.Background()
+	pool, cleanup := newReportArtifactIntegrationPool(t, ctx)
+	defer cleanup()
+
+	strategyID := seedReportArtifactStrategy(t, ctx, pool)
+	repo := NewReportArtifactRepo(pool)
+
+	timeBucket := time.Date(2026, 4, 16, 17, 0, 0, 0, time.UTC)
+	a := &ReportArtifact{
+		StrategyID: strategyID,
+		ReportType: "paper_validation",
+		TimeBucket: timeBucket,
+		Status:     "pending",
+	}
+
+	if err := repo.Upsert(ctx, a); err != nil {
+		t.Fatalf("Upsert() error = %v", err)
+	}
+	if a.ID == uuid.Nil {
+		t.Fatal("Upsert() did not populate ID")
+	}
+	if a.CreatedAt.IsZero() {
+		t.Fatal("Upsert() did not populate CreatedAt")
+	}
+}
+
+func TestReportArtifactRepo_UpsertIdempotency(t *testing.T) {
+	ctx := context.Background()
+	pool, cleanup := newReportArtifactIntegrationPool(t, ctx)
+	defer cleanup()
+
+	strategyID := seedReportArtifactStrategy(t, ctx, pool)
+	repo := NewReportArtifactRepo(pool)
+
+	timeBucket := time.Date(2026, 4, 16, 17, 0, 0, 0, time.UTC)
+	completedAt := time.Date(2026, 4, 16, 17, 1, 0, 0, time.UTC)
+
+	// First upsert — pending.
+	a := &ReportArtifact{
+		StrategyID: strategyID,
+		ReportType: "paper_validation",
+		TimeBucket: timeBucket,
+		Status:     "pending",
+	}
+	if err := repo.Upsert(ctx, a); err != nil {
+		t.Fatalf("first Upsert() error = %v", err)
+	}
+	firstID := a.ID
+
+	// Second upsert on same key — updates to completed.
+	a2 := &ReportArtifact{
+		StrategyID:  strategyID,
+		ReportType:  "paper_validation",
+		TimeBucket:  timeBucket,
+		Status:      "completed",
+		ReportJSON:  json.RawMessage(`{"score":0.92}`),
+		Provider:    "openai",
+		Model:       "gpt-5-mini",
+		PromptTokens: 100,
+		CompletionTokens: 200,
+		LatencyMs:   450,
+		CompletedAt: &completedAt,
+	}
+	if err := repo.Upsert(ctx, a2); err != nil {
+		t.Fatalf("second Upsert() error = %v", err)
+	}
+
+	// ID should be the same row (ON CONFLICT DO UPDATE returns existing id).
+	if a2.ID != firstID {
+		t.Fatalf("Upsert returned id %s, want %s (same row)", a2.ID, firstID)
+	}
+
+	// Confirm DB state reflects the update.
+	var status string
+	var reportJSON []byte
+	if err := pool.QueryRow(ctx,
+		`SELECT status, report_json FROM report_artifacts WHERE id = $1`, firstID,
+	).Scan(&status, &reportJSON); err != nil {
+		t.Fatalf("query after second Upsert() failed: %v", err)
+	}
+	if status != "completed" {
+		t.Fatalf("status = %q, want completed", status)
+	}
+	if !jsonBytesEqual(reportJSON, a2.ReportJSON) {
+		t.Fatalf("report_json = %s, want %s", reportJSON, a2.ReportJSON)
+	}
+}
+
+func TestReportArtifactRepo_GetLatestReturnsCompleted(t *testing.T) {
+	ctx := context.Background()
+	pool, cleanup := newReportArtifactIntegrationPool(t, ctx)
+	defer cleanup()
+
+	strategyID := seedReportArtifactStrategy(t, ctx, pool)
+	repo := NewReportArtifactRepo(pool)
+
+	now := time.Date(2026, 4, 16, 17, 0, 0, 0, time.UTC)
+
+	// Seed: one completed, one pending.
+	completedAt1 := now.Add(1 * time.Minute)
+	for _, a := range []*ReportArtifact{
+		{
+			StrategyID:  strategyID,
+			TimeBucket:  now.Add(-24 * time.Hour),
+			Status:      "completed",
+			Provider:    "openai",
+			Model:       "gpt-5-mini",
+			CompletedAt: &completedAt1,
+		},
+		{
+			StrategyID: strategyID,
+			TimeBucket: now,
+			Status:     "pending",
+		},
+	} {
+		a.ReportType = "paper_validation"
+		if err := repo.Upsert(ctx, a); err != nil {
+			t.Fatalf("seed Upsert() error = %v", err)
+		}
+	}
+
+	got, err := repo.GetLatest(ctx, strategyID, "paper_validation")
+	if err != nil {
+		t.Fatalf("GetLatest() error = %v", err)
+	}
+	if got == nil {
+		t.Fatal("GetLatest() = nil, want completed artifact")
+	}
+	if got.Status != "completed" {
+		t.Fatalf("GetLatest().Status = %q, want completed", got.Status)
+	}
+	if got.Provider != "openai" {
+		t.Fatalf("GetLatest().Provider = %q, want openai", got.Provider)
+	}
+}
+
+func TestReportArtifactRepo_GetLatestNilWhenNone(t *testing.T) {
+	ctx := context.Background()
+	pool, cleanup := newReportArtifactIntegrationPool(t, ctx)
+	defer cleanup()
+
+	strategyID := seedReportArtifactStrategy(t, ctx, pool)
+	repo := NewReportArtifactRepo(pool)
+
+	got, err := repo.GetLatest(ctx, strategyID, "paper_validation")
+	if err != nil {
+		t.Fatalf("GetLatest() error = %v, want nil", err)
+	}
+	if got != nil {
+		t.Fatalf("GetLatest() = %+v, want nil when no completed artifact", got)
+	}
+}
+
+func TestReportArtifactRepo_List(t *testing.T) {
+	ctx := context.Background()
+	pool, cleanup := newReportArtifactIntegrationPool(t, ctx)
+	defer cleanup()
+
+	strategyID := seedReportArtifactStrategy(t, ctx, pool)
+	otherStrategyID := seedReportArtifactStrategy(t, ctx, pool)
+	repo := NewReportArtifactRepo(pool)
+
+	now := time.Date(2026, 4, 16, 17, 0, 0, 0, time.UTC)
+
+	toSeed := []*ReportArtifact{
+		{StrategyID: strategyID, TimeBucket: now, Status: "completed"},
+		{StrategyID: strategyID, TimeBucket: now.Add(1 * time.Hour), Status: "pending"},
+		{StrategyID: otherStrategyID, TimeBucket: now, Status: "completed"},
+	}
+	for i, a := range toSeed {
+		a.ReportType = "paper_validation"
+		if err := repo.Upsert(ctx, a); err != nil {
+			t.Fatalf("seed Upsert[%d] error = %v", i, err)
+		}
+	}
+
+	// Filter by strategy.
+	artifacts, err := repo.List(ctx, ReportArtifactFilter{StrategyID: &strategyID}, 50, 0)
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(artifacts) != 2 {
+		t.Fatalf("List() returned %d artifacts, want 2", len(artifacts))
+	}
+
+	// Filter by status.
+	completed, err := repo.List(ctx, ReportArtifactFilter{Status: "completed"}, 50, 0)
+	if err != nil {
+		t.Fatalf("List(status=completed) error = %v", err)
+	}
+	if len(completed) != 2 {
+		t.Fatalf("List(status=completed) returned %d, want 2", len(completed))
+	}
+
+	// Count.
+	count, err := repo.Count(ctx, ReportArtifactFilter{StrategyID: &strategyID})
+	if err != nil {
+		t.Fatalf("Count() error = %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("Count() = %d, want 2", count)
+	}
+}
+
+func TestReportArtifactRepo_UpsertRequiresStrategyID(t *testing.T) {
+	t.Parallel()
+
+	repo := NewReportArtifactRepo(nil) // pool unused; validation happens before query
+	err := repo.Upsert(context.Background(), &ReportArtifact{
+		TimeBucket: time.Now(),
+		Status:     "pending",
+	})
+	if err == nil {
+		t.Fatal("Upsert() error = nil, want strategy_id required error")
+	}
+	if !strings.Contains(err.Error(), "strategy_id is required") {
+		t.Fatalf("error %q missing 'strategy_id is required'", err.Error())
+	}
+}
+
+func seedReportArtifactStrategy(t *testing.T, ctx context.Context, pool *pgxpool.Pool) uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO strategies (id, name, ticker, market_type) VALUES ($1, $2, $3, $4)`,
+		id, "Test Strategy "+id.String(), "AAPL", "stock",
+	); err != nil {
+		t.Fatalf("seedReportArtifactStrategy error = %v", err)
+	}
+	return id
+}

--- a/internal/repository/postgres/schema_version.go
+++ b/internal/repository/postgres/schema_version.go
@@ -9,7 +9,7 @@ import (
 )
 
 // RequiredSchemaVersion is the minimum schema version this runtime requires.
-const RequiredSchemaVersion = 28
+const RequiredSchemaVersion = 29
 
 type schemaVersionState string
 

--- a/internal/repository/postgres/schema_version_test.go
+++ b/internal/repository/postgres/schema_version_test.go
@@ -43,9 +43,9 @@ func TestCompareSchemaVersion(t *testing.T) {
 		required int
 		want     schemaVersionState
 	}{
-		{name: "behind", current: 27, required: RequiredSchemaVersion, want: schemaVersionBehind},
+		{name: "behind", current: 28, required: RequiredSchemaVersion, want: schemaVersionBehind},
 		{name: "match", current: RequiredSchemaVersion, required: RequiredSchemaVersion, want: schemaVersionMatch},
-		{name: "ahead", current: 29, required: RequiredSchemaVersion, want: schemaVersionAhead},
+		{name: "ahead", current: 30, required: RequiredSchemaVersion, want: schemaVersionAhead},
 	}
 
 	for _, tt := range tests {

--- a/migrations/000029_report_artifacts.down.sql
+++ b/migrations/000029_report_artifacts.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS report_artifacts;

--- a/migrations/000029_report_artifacts.down.sql
+++ b/migrations/000029_report_artifacts.down.sql
@@ -1,1 +1,1 @@
-DROP TABLE IF EXISTS report_artifacts;
+DROP TABLE IF EXISTS report_artifacts CASCADE;

--- a/migrations/000029_report_artifacts.up.sql
+++ b/migrations/000029_report_artifacts.up.sql
@@ -1,0 +1,19 @@
+CREATE TABLE report_artifacts (
+    id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    strategy_id       UUID NOT NULL REFERENCES strategies(id),
+    report_type       TEXT NOT NULL DEFAULT 'paper_validation',
+    time_bucket       TIMESTAMPTZ NOT NULL,
+    status            TEXT NOT NULL DEFAULT 'pending',
+    report_json       JSONB,
+    provider          TEXT,
+    model             TEXT,
+    prompt_tokens     INT DEFAULT 0,
+    completion_tokens INT DEFAULT 0,
+    latency_ms        INT DEFAULT 0,
+    error_message     TEXT,
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+    completed_at      TIMESTAMPTZ,
+    UNIQUE (strategy_id, report_type, time_bucket)
+);
+CREATE INDEX idx_report_artifacts_strategy_type
+    ON report_artifacts (strategy_id, report_type, completed_at DESC);

--- a/migrations/report_artifacts_migration_test.go
+++ b/migrations/report_artifacts_migration_test.go
@@ -171,7 +171,8 @@ func TestReportArtifactsMigrationAppliesAgainstExistingSchema(t *testing.T) {
 
 	assertIndexExists(t, ctx, pool, "report_artifacts", "idx_report_artifacts_strategy_type")
 
-	// Verify idempotency: upsert on same (strategy_id, report_type, time_bucket) should update.
+	// Verify the unique constraint: a second insert on the same
+	// (strategy_id, report_type, time_bucket) should fail.
 	strategyID := uuid.New()
 	if _, err := pool.Exec(ctx, `
 INSERT INTO strategies (id, name, ticker, market_type)

--- a/migrations/report_artifacts_migration_test.go
+++ b/migrations/report_artifacts_migration_test.go
@@ -1,0 +1,208 @@
+package migrations_test
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestReportArtifactsUpMigrationDefinesExpectedSchema(t *testing.T) {
+	upSQL := normalizeSQL(t, readMigrationFile(t, "000029_report_artifacts.up.sql"))
+
+	for _, fragment := range []string{
+		"create table report_artifacts (",
+		"id uuid primary key default gen_random_uuid()",
+		"strategy_id uuid not null references strategies(id)",
+		"report_type text not null default 'paper_validation'",
+		"time_bucket timestamptz not null",
+		"status text not null default 'pending'",
+		"report_json jsonb",
+		"provider text",
+		"model text",
+		"prompt_tokens int default 0",
+		"completion_tokens int default 0",
+		"latency_ms int default 0",
+		"error_message text",
+		"created_at timestamptz not null default now()",
+		"completed_at timestamptz",
+		"unique (strategy_id, report_type, time_bucket)",
+		"create index idx_report_artifacts_strategy_type",
+		"on report_artifacts (strategy_id, report_type, completed_at desc)",
+	} {
+		if !strings.Contains(upSQL, fragment) {
+			t.Fatalf("expected up migration to contain %q, got:\n%s", fragment, upSQL)
+		}
+	}
+}
+
+func TestReportArtifactsDownMigrationDropsTable(t *testing.T) {
+	downSQL := normalizeSQL(t, readMigrationFile(t, "000029_report_artifacts.down.sql"))
+
+	if !strings.Contains(downSQL, "drop table if exists report_artifacts") {
+		t.Fatalf("expected down migration to drop report_artifacts table, got:\n%s", downSQL)
+	}
+}
+
+func TestReportArtifactsMigrationAppliesAgainstExistingSchema(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping migration integration test in short mode")
+	}
+
+	databaseURL := os.Getenv("DB_URL")
+	if databaseURL == "" {
+		databaseURL = os.Getenv("DATABASE_URL")
+	}
+	if databaseURL == "" {
+		t.Skip("skipping migration integration test: DB_URL or DATABASE_URL is not set")
+	}
+
+	ctx := context.Background()
+
+	adminPool, err := pgxpool.New(ctx, databaseURL)
+	if err != nil {
+		t.Fatalf("failed to create admin pool: %v", err)
+	}
+	t.Cleanup(adminPool.Close)
+
+	if _, err := adminPool.Exec(ctx, `CREATE EXTENSION IF NOT EXISTS pgcrypto`); err != nil {
+		t.Fatalf("failed to ensure pgcrypto extension: %v", err)
+	}
+
+	schemaName := "migr_" + strings.ReplaceAll(uuid.NewString(), "-", "")
+	sanitizedSchemaName := pgx.Identifier{schemaName}.Sanitize()
+	if _, err := adminPool.Exec(ctx, `CREATE SCHEMA `+sanitizedSchemaName); err != nil {
+		t.Fatalf("failed to create schema: %v", err)
+	}
+	t.Cleanup(func() {
+		if _, err := adminPool.Exec(ctx, `DROP SCHEMA IF EXISTS `+sanitizedSchemaName+` CASCADE`); err != nil {
+			t.Errorf("failed to drop schema %q: %v", schemaName, err)
+		}
+	})
+
+	config, err := pgxpool.ParseConfig(databaseURL)
+	if err != nil {
+		t.Fatalf("failed to parse database config: %v", err)
+	}
+	config.ConnConfig.RuntimeParams["search_path"] = schemaName + ",public"
+	config.ConnConfig.DefaultQueryExecMode = pgx.QueryExecModeSimpleProtocol
+
+	pool, err := pgxpool.NewWithConfig(ctx, config)
+	if err != nil {
+		t.Fatalf("failed to create schema-scoped pool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	for _, filename := range sortedUpMigrationsThrough(t, "000029_report_artifacts.up.sql") {
+		if _, err := pool.Exec(ctx, readMigrationFile(t, filename)); err != nil {
+			t.Fatalf("failed to apply %s: %v", filename, err)
+		}
+	}
+
+	assertTableColumns(t, ctx, pool, "report_artifacts", map[string]columnInfo{
+		"id": {
+			dataType:      "uuid",
+			nullable:      "NO",
+			defaultClause: "gen_random_uuid()",
+		},
+		"strategy_id": {
+			dataType: "uuid",
+			nullable: "NO",
+		},
+		"report_type": {
+			dataType:      "text",
+			nullable:      "NO",
+			defaultClause: "paper_validation",
+		},
+		"time_bucket": {
+			dataType: "timestamp with time zone",
+			nullable: "NO",
+		},
+		"status": {
+			dataType:      "text",
+			nullable:      "NO",
+			defaultClause: "pending",
+		},
+		"report_json": {
+			dataType: "jsonb",
+			nullable: "YES",
+		},
+		"provider": {
+			dataType: "text",
+			nullable: "YES",
+		},
+		"model": {
+			dataType: "text",
+			nullable: "YES",
+		},
+		"prompt_tokens": {
+			dataType:      "integer",
+			nullable:      "YES",
+			defaultClause: "0",
+		},
+		"completion_tokens": {
+			dataType:      "integer",
+			nullable:      "YES",
+			defaultClause: "0",
+		},
+		"latency_ms": {
+			dataType:      "integer",
+			nullable:      "YES",
+			defaultClause: "0",
+		},
+		"error_message": {
+			dataType: "text",
+			nullable: "YES",
+		},
+		"created_at": {
+			dataType:      "timestamp with time zone",
+			nullable:      "NO",
+			defaultClause: "now()",
+		},
+		"completed_at": {
+			dataType: "timestamp with time zone",
+			nullable: "YES",
+		},
+	})
+
+	assertIndexExists(t, ctx, pool, "report_artifacts", "idx_report_artifacts_strategy_type")
+
+	// Verify idempotency: upsert on same (strategy_id, report_type, time_bucket) should update.
+	strategyID := uuid.New()
+	if _, err := pool.Exec(ctx, `
+INSERT INTO strategies (id, name, ticker, market_type)
+VALUES ($1, 'Report Strategy', 'AAPL', 'stock')
+`, strategyID); err != nil {
+		t.Fatalf("failed to seed strategy: %v", err)
+	}
+
+	timeBucket := "2026-04-16T17:00:00Z"
+	if _, err := pool.Exec(ctx, `
+INSERT INTO report_artifacts (strategy_id, report_type, time_bucket, status)
+VALUES ($1, 'paper_validation', $2::timestamptz, 'pending')
+`, strategyID, timeBucket); err != nil {
+		t.Fatalf("failed to insert first artifact: %v", err)
+	}
+
+	// Second insert on same key should conflict with the unique constraint.
+	_, err = pool.Exec(ctx, `
+INSERT INTO report_artifacts (strategy_id, report_type, time_bucket, status)
+VALUES ($1, 'paper_validation', $2::timestamptz, 'completed')
+`, strategyID, timeBucket)
+	if err == nil {
+		t.Fatal("expected unique constraint violation on duplicate (strategy_id, report_type, time_bucket), got nil")
+	}
+	if !strings.Contains(err.Error(), "unique") && !strings.Contains(err.Error(), "duplicate") {
+		t.Fatalf("expected unique/duplicate error, got: %v", err)
+	}
+
+	// Apply down migration and verify table is gone.
+	if _, err := pool.Exec(ctx, readMigrationFile(t, "000029_report_artifacts.down.sql")); err != nil {
+		t.Fatalf("failed to apply down migration: %v", err)
+	}
+	assertTableDropped(t, ctx, pool, "report_artifacts")
+}


### PR DESCRIPTION
## Summary

Migration + repository for storing LLM-generated paper validation reports. PR 4 of the [llm-resilience-refactor-plan](docs/design/llm-resilience-refactor-plan.md). No runtime job yet (that's PR 5).

## Changes

### Migrations
- **000029_report_artifacts.up.sql** — creates \`report_artifacts\` table with idempotency key \`(strategy_id, report_type, time_bucket)\`
- **000029_report_artifacts.down.sql** — \`DROP TABLE IF EXISTS report_artifacts\`
- **migrations/report_artifacts_migration_test.go** — shape tests (SQL fragments, column types, index, unique constraint, down migration)

### Repository
- **internal/repository/postgres/report_artifact.go** — \`ReportArtifactRepo\` with:
  - \`Upsert\`: INSERT … ON CONFLICT DO UPDATE (idempotent)
  - \`GetLatest(strategyID, reportType)\`: most recent \`status='completed'\` row; returns \`(nil, nil)\` when none exists
  - \`List(filter, limit, offset)\`: paginated, filterable by strategy, type, status
  - \`Count(filter)\`: count matching filter
- **internal/repository/postgres/report_artifact_test.go** — unit tests: insert, idempotency, GetLatest completed, GetLatest nil when none, List filter, Count, StrategyID required validation

### Schema version
- \`RequiredSchemaVersion\` bumped **28 → 29**
- Hardcoded version numbers updated in \`schema_version_test.go\` and \`runtime_test.go\`

### Bug fix (opportunistic)
- Removed duplicate \`validateFallbackProvider\` in \`internal/config/validate.go\` — stale inline copy left from PR 2 branching caused a build break

## Schema

\`\`\`sql
CREATE TABLE report_artifacts (
    id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
    strategy_id       UUID NOT NULL REFERENCES strategies(id),
    report_type       TEXT NOT NULL DEFAULT 'paper_validation',
    time_bucket       TIMESTAMPTZ NOT NULL,
    status            TEXT NOT NULL DEFAULT 'pending',
    report_json       JSONB,
    provider          TEXT,
    model             TEXT,
    prompt_tokens     INT DEFAULT 0,
    completion_tokens INT DEFAULT 0,
    latency_ms        INT DEFAULT 0,
    error_message     TEXT,
    created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
    completed_at      TIMESTAMPTZ,
    UNIQUE (strategy_id, report_type, time_bucket)
);
CREATE INDEX idx_report_artifacts_strategy_type
    ON report_artifacts (strategy_id, report_type, completed_at DESC);
\`\`\`