### PR TITLE
feat(web): frontend overhaul — rebrand, UX fixes, data upgrades, glossary

### DIFF
--- a/internal/data/polygon/universe.go
+++ b/internal/data/polygon/universe.go
@@ -120,11 +120,12 @@ func (c *Client) ListActiveTickers(ctx context.Context, market, tickerType strin
 			return nil, fmt.Errorf("polygon: parse next_url: %w", err)
 		}
 
-		// Rate limit pause: Polygon free tier allows 5 req/min.
+		// Rate limit pause: Polygon free tier allows 5 req/min, so paginated
+		// reference-ticker requests need roughly 12s spacing to avoid 429s.
 		select {
 		case <-ctx.Done():
 			return tickers, ctx.Err()
-		case <-time.After(250 * time.Millisecond):
+		case <-time.After(12 * time.Second):
 		}
 	}
 

--- a/internal/data/polygon/universe_test.go
+++ b/internal/data/polygon/universe_test.go
@@ -1,0 +1,52 @@
+package polygon
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestListActiveTickersRespectsFreeTierRateLimit(t *testing.T) {
+	var firstRequestAt time.Time
+	var serverURL string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Query().Get("cursor") {
+		case "":
+			firstRequestAt = time.Now()
+			_, _ = fmt.Fprintf(w, `{"results":[{"ticker":"AAA","name":"Alpha","primary_exchange":"XNAS","type":"CS","active":true}],"next_url":"%s/v3/reference/tickers?cursor=page-2"}`,
+				serverURL,
+			)
+		case "page-2":
+			if time.Since(firstRequestAt) < 11*time.Second {
+				w.WriteHeader(http.StatusTooManyRequests)
+				_, _ = w.Write([]byte(`{"status":"ERROR","request_id":"req-rate","error":"rate limit exceeded"}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"results":[{"ticker":"BBB","name":"Beta","primary_exchange":"XNYS","type":"CS","active":true}]}`))
+		default:
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+	serverURL = server.URL
+
+	client := NewClient("test-key", discardLogger())
+	client.baseURL = server.URL
+
+	tickers, err := client.ListActiveTickers(context.Background(), "stocks", "CS")
+	if err != nil {
+		t.Fatalf("ListActiveTickers() error = %v", err)
+	}
+	if len(tickers) != 2 {
+		t.Fatalf("ListActiveTickers() count = %d, want 2", len(tickers))
+	}
+	if tickers[0].Ticker != "AAA" || tickers[1].Ticker != "BBB" {
+		t.Fatalf("ListActiveTickers() tickers = %#v, want AAA then BBB", tickers)
+	}
+}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -16,6 +16,7 @@
         "lucide-react": "^0.551.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
+        "react-markdown": "^10.1.0",
         "react-router-dom": "^7.13.2",
         "recharts": "^3.8.1",
         "tailwind-merge": "^3.3.1",
@@ -2214,6 +2215,15 @@
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -2227,11 +2237,44 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "license": "MIT"
     },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -2248,7 +2291,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2263,6 +2305,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
@@ -2565,6 +2613,12 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "license": "ISC"
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
@@ -2793,6 +2847,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2899,6 +2963,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -2924,6 +2998,46 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/class-variance-authority": {
@@ -2966,6 +3080,16 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -3034,7 +3158,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -3176,7 +3299,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3203,6 +3325,19 @@
       "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -3214,7 +3349,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3227,6 +3361,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/dom-accessibility-api": {
@@ -3518,6 +3665,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -3553,6 +3710,12 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -3709,6 +3872,46 @@
         "node": ">=8"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
@@ -3720,6 +3923,16 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/ignore": {
@@ -3779,6 +3992,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
     "node_modules/internmap": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
@@ -3786,6 +4005,40 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-extglob": {
@@ -3809,6 +4062,28 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -4248,6 +4523,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -4287,12 +4572,607 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/min-indent": {
       "version": "1.0.1",
@@ -4321,7 +5201,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -4429,6 +5308,31 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
     },
     "node_modules/parse5": {
       "version": "8.0.0",
@@ -4556,6 +5460,16 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -4593,6 +5507,33 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
@@ -4722,6 +5663,39 @@
       "license": "MIT",
       "peerDependencies": {
         "redux": "^5.0.0"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/require-from-string": {
@@ -4868,6 +5842,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -4881,6 +5865,20 @@
       "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/strip-indent": {
       "version": "3.0.0",
@@ -4906,6 +5904,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
       }
     },
     "node_modules/supports-color": {
@@ -5052,6 +6068,26 @@
         "node": ">=20"
       }
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -5142,6 +6178,93 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -5190,6 +6313,34 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/victory-vendor": {
@@ -5496,6 +6647,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/web/package.json
+++ b/web/package.json
@@ -19,6 +19,7 @@
     "lucide-react": "^0.551.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
+    "react-markdown": "^10.1.0",
     "react-router-dom": "^7.13.2",
     "recharts": "^3.8.1",
     "tailwind-merge": "^3.3.1",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -26,6 +26,7 @@ import { CalendarPage } from '@/pages/calendar-page'
 import { StockDetailPage } from '@/pages/stock-detail-page'
 import { UniversePage } from '@/pages/universe-page'
 import { SignalsPage } from '@/pages/signals-page'
+import { GlossaryPage } from '@/pages/glossary-page'
 import { ReliabilityPage } from '@/pages/reliability-page'
 
 export function AppRoutes() {
@@ -60,6 +61,7 @@ export function AppRoutes() {
           <Route path="realtime" element={<RealtimePage />} />
           <Route path="signals" element={<SignalsPage />} />
           <Route path="reliability" element={<ReliabilityPage />} />
+          <Route path="glossary" element={<GlossaryPage />} />
         </Route>
       </Route>
     </Routes>

--- a/web/src/components/backtests/backtest-equity-chart.test.tsx
+++ b/web/src/components/backtests/backtest-equity-chart.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { BacktestEquityChart } from '@/components/backtests/backtest-equity-chart'
+
+vi.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div data-testid="rc">{children}</div>,
+  AreaChart: ({ children }: { children: React.ReactNode }) => <div data-testid="area-chart">{children}</div>,
+  Area: () => <div data-testid="area" />,
+  XAxis: () => <div data-testid="x-axis" />,
+  YAxis: () => <div data-testid="y-axis" />,
+  Tooltip: () => <div data-testid="tooltip" />,
+}))
+
+describe('BacktestEquityChart', () => {
+  it('renders non-empty chart data without crashing', () => {
+    render(
+      <BacktestEquityChart
+        data={[
+          {
+            timestamp: '2026-04-20T00:00:00Z',
+            cash: 100000,
+            market_value: 0,
+            portfolio_value: 100000,
+            realized_pnl: 0,
+            unrealized_pnl: 0,
+            total_pnl: 0,
+            peak_equity: 100000,
+            drawdown_pct: 0,
+          },
+          {
+            timestamp: '2026-04-21T00:00:00Z',
+            cash: 100500,
+            market_value: 750,
+            portfolio_value: 101250,
+            realized_pnl: 500,
+            unrealized_pnl: 750,
+            total_pnl: 1250,
+            peak_equity: 101250,
+            drawdown_pct: 0.01,
+          },
+        ]}
+      />,
+    )
+
+    expect(screen.getByTestId('equity-chart')).toBeInTheDocument()
+    expect(screen.getByTestId('area-chart')).toBeInTheDocument()
+  })
+
+  it('renders empty state when there is no data', () => {
+    render(<BacktestEquityChart data={[]} />)
+    expect(screen.getByTestId('equity-chart-empty')).toBeInTheDocument()
+  })
+})

--- a/web/src/components/backtests/backtest-equity-chart.tsx
+++ b/web/src/components/backtests/backtest-equity-chart.tsx
@@ -65,10 +65,12 @@ export function BacktestEquityChart({ data }: BacktestEquityChartProps) {
               borderRadius: '0.375rem',
               fontSize: '12px',
             }}
-            labelFormatter={formatDate}
-            formatter={(value: number, name: string) => {
-              if (name === 'drawdown_pct') return [`${(value * 100).toFixed(2)}%`, 'Drawdown']
-              return [formatCurrency(value), 'Portfolio Value']
+            labelFormatter={(label) => (typeof label === 'string' ? formatDate(label) : String(label ?? ''))}
+            formatter={(value, name) => {
+              const numericValue = typeof value === 'number' ? value : Number(value ?? 0)
+              const seriesName = String(name)
+              if (seriesName === 'drawdown_pct') return [`${(numericValue * 100).toFixed(2)}%`, 'Drawdown']
+              return [formatCurrency(numericValue), 'Portfolio Value']
             }}
           />
           <Area

--- a/web/src/components/chat/chat-panel.test.tsx
+++ b/web/src/components/chat/chat-panel.test.tsx
@@ -72,9 +72,9 @@ describe('ChatPanel', () => {
 
   it('renders multiple messages in order', () => {
     render(<ChatPanel messages={[userMsg, assistantMsg]} />)
-    const panel = screen.getByTestId('chat-panel')
-    const texts = Array.from(panel.querySelectorAll('p.whitespace-pre-wrap')).map((el) => el.textContent)
-    expect(texts).toEqual(['Why did you buy?', 'The bull case outweighed bear signals.'])
+    const contents = screen.getAllByTestId('chat-message-content')
+    expect(contents[0]).toHaveTextContent('Why did you buy?')
+    expect(contents[1]).toHaveTextContent('The bull case outweighed bear signals.')
   })
 
   it('renders system messages as context notes', () => {

--- a/web/src/components/chat/chat-panel.tsx
+++ b/web/src/components/chat/chat-panel.tsx
@@ -1,4 +1,5 @@
 import { type ReactNode, useEffect, useRef, useState } from 'react';
+import Markdown from 'react-markdown';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -81,7 +82,9 @@ export function ChatPanel({ messages, onSendMessage, isLoading = false, header }
                     {msg.agent_role}
                   </Badge>
                 ) : null}
-                <p className="whitespace-pre-wrap">{msg.content}</p>
+                <div className="text-sm [&_p]:mb-2 [&_p:last-child]:mb-0 [&_ul]:mb-2 [&_ul]:ml-4 [&_ul]:list-disc [&_ol]:mb-2 [&_ol]:ml-4 [&_ol]:list-decimal [&_li]:mb-0.5 [&_h1]:mb-2 [&_h1]:text-base [&_h1]:font-semibold [&_h2]:mb-1.5 [&_h2]:text-sm [&_h2]:font-semibold [&_h3]:mb-1 [&_h3]:text-sm [&_h3]:font-medium [&_code]:rounded [&_code]:bg-muted [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-[11px] [&_pre]:overflow-auto [&_pre]:rounded-md [&_pre]:border [&_pre]:border-border [&_pre]:bg-background [&_pre]:p-3 [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_blockquote]:border-l-2 [&_blockquote]:border-primary/40 [&_blockquote]:pl-3 [&_blockquote]:text-muted-foreground [&_strong]:font-semibold [&_a]:text-primary [&_a:hover]:underline" data-testid="chat-message-content">
+                  <Markdown>{msg.content}</Markdown>
+                </div>
                 <time className="mt-2 block font-mono text-[10px] uppercase tracking-[0.14em] opacity-60">
                   {new Date(msg.created_at).toLocaleTimeString()}
                 </time>

--- a/web/src/components/dashboard/activity-feed.test.tsx
+++ b/web/src/components/dashboard/activity-feed.test.tsx
@@ -1,4 +1,5 @@
-import { act, render, screen } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, cleanup, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ActivityFeed } from '@/components/dashboard/activity-feed'
@@ -34,27 +35,74 @@ class MockWebSocket {
   }
 }
 
+function Wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  }
+}
+
 describe('ActivityFeed', () => {
   beforeEach(() => {
-    vi.useFakeTimers()
     MockWebSocket.instances = []
     vi.stubGlobal('WebSocket', MockWebSocket)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve(jsonResponse({ data: [], limit: 20, offset: 0 }))),
+    )
   })
 
   afterEach(() => {
-    vi.useRealTimers()
+    cleanup()
     vi.unstubAllGlobals()
   })
 
-  it('shows empty state when no events received', () => {
-    render(<ActivityFeed />)
+  it('renders historical events from the API before live websocket updates arrive', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() =>
+        Promise.resolve(
+          jsonResponse({
+            data: [
+              {
+                id: 'evt-1',
+                pipeline_run_id: 'run-1',
+                strategy_id: 'strategy-1',
+                event_kind: 'pipeline_started',
+                title: 'Pipeline started',
+                summary: 'AAPL run kicked off',
+                created_at: '2026-04-22T00:00:00Z',
+              },
+            ],
+            limit: 20,
+            offset: 0,
+          }),
+        ),
+      ),
+    )
+
+    render(<ActivityFeed />, { wrapper: Wrapper })
+
+    expect(await screen.findByText('AAPL run kicked off')).toBeInTheDocument()
+    expect(screen.getAllByText('Pipeline started').length).toBeGreaterThan(0)
+    expect(screen.getByText(/Run: run-1/i)).toBeInTheDocument()
+  })
+
+  it('shows empty state when no events received', async () => {
+    render(<ActivityFeed />, { wrapper: Wrapper })
 
     expect(screen.getByTestId('activity-feed')).toBeInTheDocument()
-    expect(screen.getByTestId('activity-feed-empty')).toBeInTheDocument()
+    expect(await screen.findByTestId('activity-feed-empty')).toBeInTheDocument()
   })
 
   it('shows connected badge after WebSocket opens', async () => {
-    render(<ActivityFeed />)
+    render(<ActivityFeed />, { wrapper: Wrapper })
 
     const ws = MockWebSocket.instances[0]
     expect(ws).toBeDefined()
@@ -66,7 +114,7 @@ describe('ActivityFeed', () => {
   })
 
   it('renders pipeline health websocket events with a human-friendly label', async () => {
-    render(<ActivityFeed />)
+    render(<ActivityFeed />, { wrapper: Wrapper })
 
     const ws = MockWebSocket.instances[0]
     expect(ws).toBeDefined()
@@ -84,6 +132,6 @@ describe('ActivityFeed', () => {
       )
     })
 
-    expect(screen.getByText('Pipeline health')).toBeInTheDocument()
+    expect(screen.getAllByText('Pipeline health').length).toBeGreaterThan(0)
   })
 })

--- a/web/src/components/dashboard/activity-feed.tsx
+++ b/web/src/components/dashboard/activity-feed.tsx
@@ -1,64 +1,111 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { Radio, Wifi, WifiOff } from 'lucide-react';
 
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { useWebSocketClient } from '@/hooks/use-websocket-client';
-import type { WebSocketEventType, WebSocketMessage, WebSocketServerMessage } from '@/lib/api/types';
+import { apiClient } from '@/lib/api/client';
+import type { AgentEvent, WebSocketMessage, WebSocketServerMessage } from '@/lib/api/types';
 
 const MAX_FEED_ITEMS = 50;
 
 interface FeedItem {
   id: string;
-  type: WebSocketEventType;
+  type: string;
+  title: string;
+  detail?: string;
   strategyId?: string;
   runId?: string;
   timestamp: string;
-  summary: string;
 }
 
-function eventLabel(type: WebSocketEventType): string {
-  const labels: Record<WebSocketEventType, string> = {
+function eventLabel(type: string): string {
+  const labels: Record<string, string> = {
     pipeline_start: 'Pipeline started',
+    pipeline_started: 'Pipeline started',
+    pipeline_completed: 'Pipeline completed',
+    pipeline_failed: 'Pipeline failed',
+    agent_started: 'Agent started',
+    agent_completed: 'Agent completed',
     agent_decision: 'Agent decision',
     debate_round: 'Debate round',
+    debate_round_completed: 'Debate round',
     signal: 'Signal',
+    signal_produced: 'Signal produced',
     order_submitted: 'Order submitted',
     order_filled: 'Order filled',
     position_update: 'Position update',
     circuit_breaker: 'Circuit breaker',
     error: 'Error',
     pipeline_health: 'Pipeline health',
+    phase_started: 'Phase started',
+    phase_completed: 'Phase completed',
   };
-  return labels[type] ?? type;
+  return labels[type] ?? type.replace(/_/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase());
 }
 
-function eventVariant(
-  type: WebSocketEventType,
-): 'default' | 'secondary' | 'destructive' | 'success' | 'warning' {
+function eventVariant(type: string): 'default' | 'secondary' | 'destructive' | 'success' | 'warning' {
   switch (type) {
     case 'signal':
+    case 'signal_produced':
     case 'order_filled':
+    case 'pipeline_completed':
       return 'success';
     case 'circuit_breaker':
     case 'error':
+    case 'pipeline_failed':
       return 'destructive';
     case 'order_submitted':
     case 'position_update':
+    case 'pipeline_health':
       return 'warning';
     default:
       return 'secondary';
   }
 }
 
-function toFeedItem(msg: WebSocketMessage): FeedItem {
+function summarizeLiveData(data: unknown) {
+  if (typeof data === 'string') {
+    return data;
+  }
+
+  if (data && typeof data === 'object') {
+    if ('summary' in data && typeof data.summary === 'string') {
+      return data.summary;
+    }
+    if ('signal' in data && typeof data.signal === 'string') {
+      return `Signal ${String(data.signal).toUpperCase()}`;
+    }
+    if ('ticker' in data && typeof data.ticker === 'string') {
+      return `Ticker ${data.ticker}`;
+    }
+  }
+
+  return undefined;
+}
+
+function toHistoricalFeedItem(event: AgentEvent): FeedItem {
   return {
-    id: `${msg.type}-${msg.timestamp ?? Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    id: event.id,
+    type: event.event_kind,
+    title: event.title || eventLabel(event.event_kind),
+    detail: event.summary,
+    strategyId: event.strategy_id,
+    runId: event.pipeline_run_id,
+    timestamp: event.created_at,
+  };
+}
+
+function toLiveFeedItem(msg: WebSocketMessage): FeedItem {
+  return {
+    id: `${msg.type}-${msg.run_id ?? 'none'}-${msg.timestamp ?? Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
     type: msg.type,
+    title: eventLabel(msg.type),
+    detail: summarizeLiveData(msg.data),
     strategyId: msg.strategy_id,
     runId: msg.run_id,
     timestamp: msg.timestamp ?? new Date().toISOString(),
-    summary: eventLabel(msg.type),
   };
 }
 
@@ -67,15 +114,20 @@ function isWebSocketMessage(msg: WebSocketServerMessage): msg is WebSocketMessag
 }
 
 export function ActivityFeed() {
-  const [items, setItems] = useState<FeedItem[]>([]);
+  const [liveItems, setLiveItems] = useState<FeedItem[]>([]);
   const subscribedRef = useRef(false);
+  const { data } = useQuery({
+    queryKey: ['events', 'dashboard-activity-feed'],
+    queryFn: () => apiClient.listEvents({ limit: 20 }),
+    refetchInterval: 30_000,
+  });
 
   const handleMessage = useCallback((msg: WebSocketServerMessage) => {
     if (!isWebSocketMessage(msg)) return;
 
-    const item = toFeedItem(msg);
+    const item = toLiveFeedItem(msg);
 
-    setItems((prev) => {
+    setLiveItems((prev) => {
       const next = [item, ...prev];
       return next.length > MAX_FEED_ITEMS ? next.slice(0, MAX_FEED_ITEMS) : next;
     });
@@ -97,6 +149,21 @@ export function ActivityFeed() {
       subscribedRef.current = false;
     }
   }, [isConnected, subscribeAll]);
+
+  const items = useMemo(() => {
+    const historicalItems = (data?.data ?? []).map(toHistoricalFeedItem);
+    const merged = [...liveItems, ...historicalItems];
+    const byId = new Map<string, FeedItem>();
+    for (const item of merged) {
+      if (!byId.has(item.id)) {
+        byId.set(item.id, item);
+      }
+    }
+
+    return Array.from(byId.values())
+      .sort((left, right) => new Date(right.timestamp).getTime() - new Date(left.timestamp).getTime())
+      .slice(0, MAX_FEED_ITEMS);
+  }, [data?.data, liveItems]);
 
   return (
     <Card data-testid="activity-feed">
@@ -131,13 +198,17 @@ export function ActivityFeed() {
                 className="flex items-start gap-3 rounded-lg border border-border p-3 text-sm transition-colors hover:bg-accent/45"
               >
                 <Badge variant={eventVariant(item.type)} className="mt-0.5 shrink-0">
-                  {item.summary}
+                  {eventLabel(item.type)}
                 </Badge>
-                <div className="min-w-0 flex-1 font-mono text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
-                  {item.strategyId ? (
-                    <span className="mr-2">Strategy: {item.strategyId.slice(0, 8)}…</span>
-                  ) : null}
-                  {item.runId ? <span>Run: {item.runId.slice(0, 8)}…</span> : null}
+                <div className="min-w-0 flex-1">
+                  <p className="truncate font-medium text-foreground">{item.title}</p>
+                  {item.detail ? <p className="mt-1 text-sm text-muted-foreground">{item.detail}</p> : null}
+                  <div className="mt-2 font-mono text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
+                    {item.strategyId ? (
+                      <span className="mr-2">Strategy: {item.strategyId.slice(0, 8)}…</span>
+                    ) : null}
+                    {item.runId ? <span>Run: {item.runId}</span> : null}
+                  </div>
                 </div>
                 <time
                   className="shrink-0 font-mono text-[11px] uppercase tracking-[0.14em] text-muted-foreground"

--- a/web/src/components/dashboard/recent-runs.test.tsx
+++ b/web/src/components/dashboard/recent-runs.test.tsx
@@ -1,0 +1,70 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { RecentRuns } from '@/components/dashboard/recent-runs'
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  }
+}
+
+describe('RecentRuns', () => {
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllGlobals()
+  })
+
+  it('renders recent pipeline runs from the API', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() =>
+        Promise.resolve(
+          jsonResponse({
+            data: [
+              {
+                id: 'run-1',
+                strategy_id: 'strategy-1',
+                ticker: 'AAPL',
+                trade_date: '2026-04-22T00:00:00Z',
+                status: 'completed',
+                signal: 'buy',
+                started_at: '2026-04-22T00:00:00Z',
+                completed_at: '2026-04-22T00:03:00Z',
+              },
+            ],
+            limit: 10,
+            offset: 0,
+          }),
+        ),
+      ),
+    )
+
+    render(<RecentRuns />, { wrapper: Wrapper })
+
+    expect(await screen.findByText('Recent runs')).toBeInTheDocument()
+    expect(await screen.findByText('AAPL')).toBeInTheDocument()
+    expect(screen.getByText('Completed')).toBeInTheDocument()
+    expect(screen.getByText('buy')).toBeInTheDocument()
+  })
+
+  it('shows empty state when no runs are available', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve(jsonResponse({ data: [], limit: 10, offset: 0 }))),
+    )
+
+    render(<RecentRuns />, { wrapper: Wrapper })
+
+    expect(await screen.findByTestId('recent-runs-empty')).toBeInTheDocument()
+    expect(screen.getByText('No runs yet')).toBeInTheDocument()
+  })
+})

--- a/web/src/components/dashboard/recent-runs.tsx
+++ b/web/src/components/dashboard/recent-runs.tsx
@@ -1,0 +1,81 @@
+import { useQuery } from '@tanstack/react-query';
+import { Clock } from 'lucide-react';
+
+import { RunSignalBadge, RunStatusBadge } from '@/components/runs/run-badges';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { apiClient } from '@/lib/api/client';
+import type { PipelineRun } from '@/lib/api/types';
+import { formatRunDate } from '@/lib/run-format';
+
+const RECENT_RUN_LIMIT = 10;
+
+function RunRow({ run }: { run: PipelineRun }) {
+  return (
+    <li className="flex items-center gap-3 rounded-lg border border-border bg-background p-3 transition-colors hover:border-primary/15 hover:bg-accent/45">
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <p className="truncate text-sm font-medium">{run.ticker}</p>
+          {run.signal ? <RunSignalBadge signal={run.signal} /> : null}
+        </div>
+        <p className="mt-1 flex items-center gap-1 font-mono text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
+          <Clock className="size-3" />
+          {formatRunDate(run.started_at)}
+          {run.completed_at ? ` — ${formatRunDate(run.completed_at)}` : ''}
+        </p>
+      </div>
+      <RunStatusBadge status={run.status} />
+    </li>
+  );
+}
+
+export function RecentRuns() {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['runs', 'dashboard-recent'],
+    queryFn: () => apiClient.listRuns({ limit: RECENT_RUN_LIMIT }),
+    refetchInterval: 15_000,
+  });
+
+  const runs = data?.data ?? [];
+
+  return (
+    <Card data-testid="recent-runs">
+      <CardHeader>
+        <CardTitle>Recent runs</CardTitle>
+        <CardDescription>Latest pipeline executions across strategies</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="space-y-3" data-testid="recent-runs-loading">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div
+                key={i}
+                className="flex items-center gap-3 rounded-lg border border-border bg-background p-3"
+              >
+                <div className="h-4 w-24 animate-pulse rounded bg-muted" />
+                <div className="ml-auto h-5 w-16 animate-pulse rounded-full bg-muted" />
+              </div>
+            ))}
+          </div>
+        ) : isError ? (
+          <p className="text-sm text-muted-foreground" data-testid="recent-runs-error">
+            Unable to load recent runs.
+          </p>
+        ) : runs.length === 0 ? (
+          <div
+            className="flex flex-col items-center gap-2 rounded-lg border border-dashed border-border bg-background py-10 text-center"
+            data-testid="recent-runs-empty"
+          >
+            <Clock className="size-8 text-muted-foreground" />
+            <p className="text-sm text-muted-foreground">No runs yet</p>
+          </div>
+        ) : (
+          <ul className="space-y-2" data-testid="recent-runs-list">
+            {runs.map((run) => (
+              <RunRow key={run.id} run={run} />
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/web/src/components/layout/app-shell.test.tsx
+++ b/web/src/components/layout/app-shell.test.tsx
@@ -16,7 +16,7 @@ describe('AppShell', () => {
       </MemoryRouter>,
     )
 
-    expect(screen.getAllByText('Get Rich Quick').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByText('Augr').length).toBeGreaterThanOrEqual(1)
     expect(screen.getAllByRole('link', { name: /memories/i }).length).toBeGreaterThanOrEqual(1)
     expect(screen.getAllByRole('link', { name: /settings/i }).length).toBeGreaterThanOrEqual(1)
     const portfolioLinks = screen.getAllByRole('link', { name: /portfolio/i })

--- a/web/src/components/layout/app-shell.tsx
+++ b/web/src/components/layout/app-shell.tsx
@@ -1,5 +1,6 @@
 import {
   Activity,
+  BookOpen,
   Brain,
   BriefcaseBusiness,
   CalendarDays,
@@ -35,6 +36,7 @@ const navigationItems = [
   { to: '/signals', label: 'Signals', icon: Signal },
   { to: '/reliability', label: 'Reliability', icon: ShieldCheck },
   { to: '/memories', label: 'Memories', icon: Brain },
+  { to: '/glossary', label: 'Glossary', icon: BookOpen },
   { to: '/settings', label: 'Settings', icon: Settings2 },
   { to: '/risk', label: 'Risk', icon: ShieldAlert },
   { to: '/realtime', label: 'Realtime', icon: RadioTower },
@@ -49,7 +51,7 @@ export function AppShell() {
         <div className="sticky top-3 flex h-[calc(100vh-1.5rem)] flex-col rounded-lg border border-border bg-card p-3">
           <div className="border-b border-border pb-3">
             <p className="font-mono text-[11px] font-medium uppercase tracking-[0.18em] text-primary">
-              Get Rich Quick
+              Augr
             </p>
           </div>
 
@@ -79,14 +81,14 @@ export function AppShell() {
       <div className="flex min-h-screen min-w-0 flex-1 flex-col gap-3">
         <header className="sticky top-3 z-20 flex items-center justify-between rounded-lg border border-border bg-card px-4 py-2.5">
           <div className="flex items-center gap-2 text-sm">
-            <span className="font-semibold text-foreground">Get Rich Quick</span>
+            <span className="font-semibold text-foreground">Augr</span>
             <span className="text-muted-foreground">/</span>
             <span className="text-muted-foreground">{location.pathname === '/' ? 'overview' : location.pathname.slice(1)}</span>
           </div>
 
           <nav
             aria-label="Primary mobile"
-            className="flex gap-1.5 overflow-x-auto lg:hidden"
+            className="flex gap-1.5 overflow-x-auto scrollbar-none lg:hidden"
           >
             {navigationItems.map(({ to, label, icon: Icon }) => (
               <NavLink

--- a/web/src/components/pipeline/analyst-cards.tsx
+++ b/web/src/components/pipeline/analyst-cards.tsx
@@ -74,8 +74,8 @@ export function AnalystCards({
               <CardContent>
                 {decision ? (
                   <>
-                    <p className="line-clamp-3 text-xs text-muted-foreground">
-                      {decision.output_text.slice(0, 200)}
+                    <p className="whitespace-pre-wrap text-xs leading-relaxed text-muted-foreground">
+                      {decision.output_text}
                     </p>
                     {decision.latency_ms !== undefined && (
                       <Badge variant="outline" className="mt-2 text-[10px]">

--- a/web/src/components/pipeline/decision-inspector.test.tsx
+++ b/web/src/components/pipeline/decision-inspector.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { DecisionInspector } from '@/components/pipeline/decision-inspector'
+
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogContent: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
+}))
+
+describe('DecisionInspector', () => {
+  it('renders structured output safely', () => {
+    render(
+      <DecisionInspector
+        decision={{
+          id: 'dec-1',
+          pipeline_run_id: 'run-1',
+          agent_role: 'trader',
+          phase: 'trading',
+          output_text: 'Buy',
+          output_structured: { action: 'buy', confidence: 0.82 },
+          created_at: '2026-04-22T00:00:00Z',
+        }}
+        onClose={() => {}}
+      />,
+    )
+
+    expect(screen.getByTestId('inspector-structured')).toHaveTextContent('confidence')
+  })
+})

--- a/web/src/components/pipeline/decision-inspector.tsx
+++ b/web/src/components/pipeline/decision-inspector.tsx
@@ -123,7 +123,7 @@ export function DecisionInspector({ decision, onClose }: DecisionInspectorProps)
             </pre>
           </section>
 
-          {decision.output_structured && (
+          {decision.output_structured != null && (
             <section className="space-y-1.5">
               <h4 className="font-mono text-[11px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
                 Structured Output

--- a/web/src/components/pipeline/decision-inspector.tsx
+++ b/web/src/components/pipeline/decision-inspector.tsx
@@ -116,7 +116,7 @@ export function DecisionInspector({ decision, onClose }: DecisionInspectorProps)
               LLM Response
             </h4>
             <pre
-              className="max-h-96 overflow-y-auto whitespace-pre-wrap rounded-md border border-border bg-background p-3 font-mono text-[12px] leading-5 text-foreground"
+              className="overflow-y-auto whitespace-pre-wrap rounded-md border border-border bg-background p-3 font-mono text-[12px] leading-5 text-foreground"
               data-testid="inspector-response"
             >
               {decision.output_text}

--- a/web/src/components/pipeline/final-signal.tsx
+++ b/web/src/components/pipeline/final-signal.tsx
@@ -117,14 +117,14 @@ export function FinalSignal({ signal, signalDecision, onSelectDecision }: FinalS
                 )}
               </div>
               {signalDecision && (
-                <p className="line-clamp-4 text-xs text-muted-foreground">
-                  {signalDecision.output_text.slice(0, 400)}
+                <p className="whitespace-pre-wrap text-xs leading-relaxed text-muted-foreground">
+                  {signalDecision.output_text}
                 </p>
               )}
             </div>
           ) : signalDecision ? (
-            <p className="line-clamp-4 text-xs text-muted-foreground">
-              {signalDecision.output_text.slice(0, 400)}
+            <p className="whitespace-pre-wrap text-xs leading-relaxed text-muted-foreground">
+              {signalDecision.output_text}
             </p>
           ) : (
             <p className="text-xs text-muted-foreground">Waiting for final signal…</p>

--- a/web/src/components/universe/watchlist-table.test.tsx
+++ b/web/src/components/universe/watchlist-table.test.tsx
@@ -1,0 +1,71 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it, vi } from 'vitest'
+
+import { WatchlistTable } from '@/components/universe/watchlist-table'
+
+const navigateMock = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  }
+})
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return (
+    <QueryClientProvider client={client}>
+      <MemoryRouter>{children}</MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+describe('WatchlistTable', () => {
+  it('renders scored tickers using score field', () => {
+    render(
+      <WatchlistTable
+        tickers={[
+          {
+            ticker: 'AAPL',
+            score: 0.82,
+            reasons: ['gap_up'],
+            day_volume: 1200000,
+            day_close: 182.35,
+            change_pct: 1.2,
+            gap_pct: 0.6,
+          },
+        ]}
+      />,
+      { wrapper: Wrapper },
+    )
+
+    expect(screen.getByText('AAPL')).toBeInTheDocument()
+    expect(screen.getByText('0.82')).toBeInTheDocument()
+    expect(screen.getByText('gap_up')).toBeInTheDocument()
+  })
+
+  it('navigates to discovery with selected ticker when row clicked', () => {
+    render(
+      <WatchlistTable
+        tickers={[
+          {
+            ticker: 'TSLA',
+            score: 0.55,
+            reasons: [],
+            day_volume: 1000,
+            day_close: 250,
+            change_pct: -0.5,
+            gap_pct: 0,
+          },
+        ]}
+      />,
+      { wrapper: Wrapper },
+    )
+
+    fireEvent.click(screen.getByText('TSLA'))
+    expect(navigateMock).toHaveBeenCalledWith('/discovery?tickers=TSLA')
+  })
+})

--- a/web/src/components/universe/watchlist-table.test.tsx
+++ b/web/src/components/universe/watchlist-table.test.tsx
@@ -47,6 +47,28 @@ describe('WatchlistTable', () => {
     expect(screen.getByText('gap_up')).toBeInTheDocument()
   })
 
+  it('renders 0.00 when score is undefined (null-guard)', () => {
+    render(
+      <WatchlistTable
+        tickers={[
+          {
+            ticker: 'MSFT',
+            score: undefined as unknown as number,
+            reasons: [],
+            day_volume: 500000,
+            day_close: 300,
+            change_pct: 0,
+            gap_pct: 0,
+          },
+        ]}
+      />,
+      { wrapper: Wrapper },
+    )
+
+    expect(screen.getByText('MSFT')).toBeInTheDocument()
+    expect(screen.getByText('0.00')).toBeInTheDocument()
+  })
+
   it('navigates to discovery with selected ticker when row clicked', () => {
     render(
       <WatchlistTable

--- a/web/src/components/universe/watchlist-table.tsx
+++ b/web/src/components/universe/watchlist-table.tsx
@@ -45,8 +45,8 @@ export function WatchlistTable({ tickers }: WatchlistTableProps) {
             >
               <td className="px-2 py-1.5 font-mono font-medium">{t.ticker}</td>
               <td className="px-2 py-1.5">
-                <Badge variant={scoreBadgeVariant(t.score ?? t.watch_score ?? 0)}>
-                  {(t.score ?? t.watch_score ?? 0).toFixed(2)}
+                <Badge variant={scoreBadgeVariant(t.score)}>
+                  {t.score.toFixed(2)}
                 </Badge>
               </td>
               <td

--- a/web/src/components/universe/watchlist-table.tsx
+++ b/web/src/components/universe/watchlist-table.tsx
@@ -7,9 +7,9 @@ interface WatchlistTableProps {
   tickers: ScoredTicker[]
 }
 
-function scoreBadgeVariant(score: number) {
-  if (score > 0.7) return 'success' as const
-  if (score > 0.4) return 'warning' as const
+function scoreBadgeVariant(score: number | undefined) {
+  if ((score ?? 0) > 0.7) return 'success' as const
+  if ((score ?? 0) > 0.4) return 'warning' as const
   return 'destructive' as const
 }
 
@@ -46,7 +46,7 @@ export function WatchlistTable({ tickers }: WatchlistTableProps) {
               <td className="px-2 py-1.5 font-mono font-medium">{t.ticker}</td>
               <td className="px-2 py-1.5">
                 <Badge variant={scoreBadgeVariant(t.score)}>
-                  {t.score.toFixed(2)}
+                  {(t.score ?? 0).toFixed(2)}
                 </Badge>
               </td>
               <td

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -63,9 +63,20 @@
   --radius-xl: calc(var(--radius) + 4px);
 }
 
+@utility scrollbar-none {
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
 @layer base {
   * {
     @apply border-border;
+  }
+
+  html {
+    font-size: 93.75%; /* 15px base — density-optimised for 85%-zoom users */
   }
 
   html,

--- a/web/src/pages/dashboard-page.test.tsx
+++ b/web/src/pages/dashboard-page.test.tsx
@@ -42,18 +42,16 @@ function Wrapper({ children }: { children: React.ReactNode }) {
 
 describe('DashboardPage', () => {
   beforeEach(() => {
-    vi.useFakeTimers()
     MockWebSocket.instances = []
     vi.stubGlobal('WebSocket', MockWebSocket)
   })
 
   afterEach(() => {
     cleanup()
-    vi.useRealTimers()
     vi.unstubAllGlobals()
   })
 
-  it('renders all dashboard sections', async () => {
+  it('renders dashboard activity and recent runs from the API', async () => {
     const fetchMock = vi.fn((input: RequestInfo | URL) => {
       const url = typeof input === 'string' ? input : input.toString()
 
@@ -62,6 +60,51 @@ describe('DashboardPage', () => {
           ok: true,
           status: 200,
           json: async () => ({ open_positions: 0, unrealized_pnl: 0, realized_pnl: 0 }),
+        })
+      }
+
+      if (url.includes('/api/v1/runs')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            data: [
+              {
+                id: 'run-1',
+                strategy_id: 'strategy-1',
+                ticker: 'AAPL',
+                trade_date: '2026-04-22T00:00:00Z',
+                status: 'completed',
+                signal: 'buy',
+                started_at: '2026-04-22T00:00:00Z',
+                completed_at: '2026-04-22T00:03:00Z',
+              },
+            ],
+            limit: 10,
+            offset: 0,
+          }),
+        })
+      }
+
+      if (url.includes('/api/v1/events')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            data: [
+              {
+                id: 'evt-1',
+                pipeline_run_id: 'run-1',
+                strategy_id: 'strategy-1',
+                event_kind: 'pipeline_started',
+                title: 'Pipeline started',
+                summary: 'AAPL run kicked off',
+                created_at: '2026-04-22T00:00:00Z',
+              },
+            ],
+            limit: 20,
+            offset: 0,
+          }),
         })
       }
 
@@ -93,8 +136,11 @@ describe('DashboardPage', () => {
 
     render(<DashboardPage />, { wrapper: Wrapper })
 
-    expect(screen.getByTestId('dashboard-page')).toBeInTheDocument()
-    expect(screen.getByTestId('activity-feed')).toBeInTheDocument()
+    expect(await screen.findByTestId('dashboard-page')).toBeInTheDocument()
+    expect(await screen.findByText('AAPL run kicked off')).toBeInTheDocument()
+    expect(screen.getAllByText('Pipeline started').length).toBeGreaterThan(0)
+    expect(await screen.findByText('Recent runs')).toBeInTheDocument()
+    expect(await screen.findByText('AAPL')).toBeInTheDocument()
   })
 
   it('renders when the active strategies data array is null', async () => {

--- a/web/src/pages/dashboard-page.tsx
+++ b/web/src/pages/dashboard-page.tsx
@@ -4,6 +4,7 @@ import { UpcomingEventsWidget } from '@/components/calendar/upcoming-events-widg
 import { ActiveStrategies } from '@/components/dashboard/active-strategies'
 import { ActivityFeed } from '@/components/dashboard/activity-feed'
 import { PortfolioSummary } from '@/components/dashboard/portfolio-summary'
+import { RecentRuns } from '@/components/dashboard/recent-runs'
 import { PageHeader } from '@/components/layout/page-header'
 import { RiskStatusBar } from '@/components/dashboard/risk-status-bar'
 import { Badge } from '@/components/ui/badge'
@@ -34,6 +35,7 @@ export function DashboardPage() {
       <div className="grid gap-4 xl:grid-cols-[minmax(0,1.4fr)_minmax(320px,0.9fr)]">
         <div className="space-y-4">
           <ActiveStrategies />
+          <RecentRuns />
           <ActivityFeed />
         </div>
 

--- a/web/src/pages/glossary-page.test.tsx
+++ b/web/src/pages/glossary-page.test.tsx
@@ -1,0 +1,64 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { GlossaryPage, GLOSSARY_TERMS } from '@/pages/glossary-page'
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <GlossaryPage />
+    </MemoryRouter>,
+  )
+}
+
+describe('GlossaryPage', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders the page heading', () => {
+    renderPage()
+    expect(screen.getByTestId('glossary-page')).toBeInTheDocument()
+  })
+
+  it('renders all terms by default', () => {
+    renderPage()
+    for (const term of GLOSSARY_TERMS) {
+      expect(screen.getByTestId(`glossary-term-${term.slug}`)).toBeInTheDocument()
+    }
+  })
+
+  it('filters terms by search query (term name)', () => {
+    renderPage()
+    const input = screen.getByTestId('glossary-search')
+    fireEvent.change(input, { target: { value: 'kill switch' } })
+
+    expect(screen.getByTestId('glossary-term-kill-switch')).toBeInTheDocument()
+    expect(screen.queryByTestId('glossary-term-backtest')).not.toBeInTheDocument()
+  })
+
+  it('filters terms by definition keyword', () => {
+    renderPage()
+    const input = screen.getByTestId('glossary-search')
+    fireEvent.change(input, { target: { value: 'websocket' } })
+
+    expect(screen.getByTestId('glossary-term-realtime')).toBeInTheDocument()
+  })
+
+  it('shows empty state when no terms match', () => {
+    renderPage()
+    const input = screen.getByTestId('glossary-search')
+    fireEvent.change(input, { target: { value: 'zzznomatchzzz' } })
+
+    expect(screen.getByTestId('glossary-empty')).toBeInTheDocument()
+  })
+
+  it('groups terms alphabetically', () => {
+    renderPage()
+    const headings = screen.getAllByRole('heading', { level: 2 })
+    const letters = headings.map((h) => h.textContent)
+    const sorted = [...letters].sort()
+    expect(letters).toEqual(sorted)
+  })
+})

--- a/web/src/pages/glossary-page.tsx
+++ b/web/src/pages/glossary-page.tsx
@@ -1,0 +1,346 @@
+import { BookOpen, Search } from 'lucide-react'
+import { useMemo, useState } from 'react'
+
+import { PageHeader } from '@/components/layout/page-header'
+import { Badge } from '@/components/ui/badge'
+import { Input } from '@/components/ui/input'
+
+// ---- term data ----
+
+export interface GlossaryTerm {
+  term: string
+  slug: string
+  category: string
+  definition: string
+}
+
+export const GLOSSARY_TERMS: GlossaryTerm[] = [
+  {
+    term: 'AMC',
+    slug: 'amc',
+    category: 'earnings',
+    definition:
+      'After Market Close — an earnings report released after the trading day ends. Prices may gap at the next open.',
+  },
+  {
+    term: 'Automation',
+    slug: 'automation',
+    category: 'system',
+    definition:
+      'Scheduled or event-driven workflows that run strategies, send alerts, or perform maintenance tasks without manual intervention.',
+  },
+  {
+    term: 'Backtest',
+    slug: 'backtest',
+    category: 'strategy',
+    definition:
+      'A simulated test of a strategy against historical price data to evaluate how it would have performed in the past.',
+  },
+  {
+    term: 'BMO',
+    slug: 'bmo',
+    category: 'earnings',
+    definition:
+      'Before Market Open — an earnings report released before the trading day starts. Prices may gap at the open.',
+  },
+  {
+    term: 'Circuit Breaker',
+    slug: 'circuit-breaker',
+    category: 'risk',
+    definition:
+      'An automated control that pauses trading when specific risk thresholds are breached, preventing further losses until manually reviewed.',
+  },
+  {
+    term: 'Discovery',
+    slug: 'discovery',
+    category: 'system',
+    definition:
+      'An AI-powered scan that analyzes the universe of tracked securities and surfaces the most promising opportunities based on configured criteria.',
+  },
+  {
+    term: 'EPS',
+    slug: 'eps',
+    category: 'earnings',
+    definition:
+      "Earnings Per Share — a company's net profit divided by the number of outstanding shares. A key metric for comparing earnings reports against analyst estimates.",
+  },
+  {
+    term: 'Fill Price',
+    slug: 'fill-price',
+    category: 'orders',
+    definition:
+      'The actual price at which an order was executed, which may differ from the limit or market price requested.',
+  },
+  {
+    term: 'Gap',
+    slug: 'gap',
+    category: 'price',
+    definition:
+      "A price difference between a stock's prior close and the next open, caused by overnight news or earnings releases.",
+  },
+  {
+    term: 'Kill Switch',
+    slug: 'kill-switch',
+    category: 'risk',
+    definition:
+      'An emergency control that immediately halts all trading activity system-wide. Requires manual reactivation to resume.',
+  },
+  {
+    term: 'Long',
+    slug: 'long',
+    category: 'positions',
+    definition:
+      'A position that profits when the underlying security rises in price. The standard direction for most equity trades.',
+  },
+  {
+    term: 'Memory',
+    slug: 'memory',
+    category: 'system',
+    definition:
+      'Stored knowledge — facts, summaries, and decisions — that agents reference across sessions to inform future analysis.',
+  },
+  {
+    term: 'Options Chain',
+    slug: 'options-chain',
+    category: 'options',
+    definition:
+      'A listing of all available option contracts (calls and puts) for a given security, organized by expiry date and strike price.',
+  },
+  {
+    term: 'P&L',
+    slug: 'pnl',
+    category: 'positions',
+    definition:
+      'Profit and Loss — the difference between realized or unrealized revenue and the cost of entering a position. Displayed as both a dollar amount and percentage.',
+  },
+  {
+    term: 'Paper Trading',
+    slug: 'paper-trading',
+    category: 'strategy',
+    definition:
+      'Simulated trading with no real money at risk. Used to validate strategy behavior before live deployment.',
+  },
+  {
+    term: 'Pipeline Run',
+    slug: 'pipeline-run',
+    category: 'system',
+    definition:
+      "A single execution of a strategy's analysis pipeline, encompassing all agent phases from data ingestion through final signal generation.",
+  },
+  {
+    term: 'Position',
+    slug: 'position',
+    category: 'positions',
+    definition:
+      'An open trade holding shares or contracts. Shows current price, unrealized P&L, and stop/take-profit levels.',
+  },
+  {
+    term: 'Realtime',
+    slug: 'realtime',
+    category: 'system',
+    definition:
+      'A live event feed that streams pipeline runs and agent activity as they happen via WebSocket, with conversation context for each event.',
+  },
+  {
+    term: 'Reliability',
+    slug: 'reliability',
+    category: 'system',
+    definition:
+      'System health metrics tracking uptime, latency percentiles, and error rates across pipeline components.',
+  },
+  {
+    term: 'SEC Filing',
+    slug: 'sec-filing',
+    category: 'fundamentals',
+    definition:
+      'Documents required by the Securities and Exchange Commission, including 10-K annual reports, 10-Q quarterly reports, and 8-K material event disclosures. Can be analyzed by the AI pipeline for trading signals.',
+  },
+  {
+    term: 'Sentiment',
+    slug: 'sentiment',
+    category: 'signals',
+    definition:
+      'An analyst assessment of whether a signal or filing is bullish (positive), bearish (negative), or neutral. Used to classify pipeline outputs.',
+  },
+  {
+    term: 'Short',
+    slug: 'short',
+    category: 'positions',
+    definition:
+      'A position that profits when the underlying security falls in price. Involves borrowing shares to sell, then buying them back at a lower price.',
+  },
+  {
+    term: 'Signal',
+    slug: 'signal',
+    category: 'signals',
+    definition:
+      'A trading recommendation generated at the end of a pipeline run: buy, sell, or hold. Accompanied by confidence score and agent reasoning.',
+  },
+  {
+    term: 'Stop Loss',
+    slug: 'stop-loss',
+    category: 'risk',
+    definition:
+      'A price level at which a losing position is automatically closed to cap downside. Set per-position based on strategy risk parameters.',
+  },
+  {
+    term: 'Strategy',
+    slug: 'strategy',
+    category: 'strategy',
+    definition:
+      'A configured set of agents, tickers, schedule, and risk parameters that define how the system analyzes and trades a security.',
+  },
+  {
+    term: 'Take Profit',
+    slug: 'take-profit',
+    category: 'risk',
+    definition:
+      'A price level at which a profitable position is automatically closed to lock in gains. Works alongside stop loss for symmetric risk management.',
+  },
+  {
+    term: 'Ticker',
+    slug: 'ticker',
+    category: 'price',
+    definition:
+      'A unique symbol identifying a publicly traded security (e.g., AAPL for Apple Inc.). Used across the system to reference stocks, ETFs, and other instruments.',
+  },
+  {
+    term: 'Universe',
+    slug: 'universe',
+    category: 'system',
+    definition:
+      'The full set of securities tracked and scored by the system. Securities are ranked by watch score to surface the most relevant candidates.',
+  },
+  {
+    term: 'Watch Score',
+    slug: 'watch-score',
+    category: 'signals',
+    definition:
+      'A composite ranking score indicating how much attention a ticker deserves. Higher scores reflect stronger technical and fundamental signals.',
+  },
+  {
+    term: 'Watchlist',
+    slug: 'watchlist',
+    category: 'system',
+    definition:
+      'The active subset of the universe currently under close monitoring. Populated by the Discovery scan and scored tickers above configured thresholds.',
+  },
+]
+
+// ---- category labels ----
+
+const CATEGORY_LABELS: Record<string, string> = {
+  earnings: 'Earnings',
+  fundamentals: 'Fundamentals',
+  options: 'Options',
+  orders: 'Orders',
+  positions: 'Positions',
+  price: 'Price',
+  risk: 'Risk',
+  signals: 'Signals',
+  strategy: 'Strategy',
+  system: 'System',
+}
+
+// ---- component ----
+
+export function GlossaryPage() {
+  const [query, setQuery] = useState('')
+
+  const filtered = useMemo(() => {
+    const q = query.toLowerCase().trim()
+    if (!q) return GLOSSARY_TERMS
+    return GLOSSARY_TERMS.filter(
+      (t) =>
+        t.term.toLowerCase().includes(q) ||
+        t.definition.toLowerCase().includes(q) ||
+        t.category.toLowerCase().includes(q),
+    )
+  }, [query])
+
+  // group by first letter
+  const groups = useMemo(() => {
+    const map = new Map<string, GlossaryTerm[]>()
+    for (const term of filtered) {
+      const letter = term.term[0].toUpperCase()
+      if (!map.has(letter)) map.set(letter, [])
+      map.get(letter)!.push(term)
+    }
+    return Array.from(map.entries()).sort(([a], [b]) => a.localeCompare(b))
+  }, [filtered])
+
+  return (
+    <div className="space-y-4" data-testid="glossary-page">
+      <PageHeader
+        eyebrow="Reference"
+        title="Glossary"
+        description="Definitions for terms used throughout Augr"
+      />
+
+      {/* Search */}
+      <div className="relative max-w-sm">
+        <Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Filter terms…"
+          className="pl-8 text-sm"
+          data-testid="glossary-search"
+        />
+      </div>
+
+      {/* Results */}
+      {groups.length === 0 ? (
+        <p className="text-sm text-muted-foreground" data-testid="glossary-empty">
+          No terms match "{query}".
+        </p>
+      ) : (
+        <div className="space-y-8">
+          {groups.map(([letter, terms]) => (
+            <section key={letter} aria-labelledby={`glossary-letter-${letter}`}>
+              <h2
+                id={`glossary-letter-${letter}`}
+                className="mb-3 font-mono text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground"
+              >
+                {letter}
+              </h2>
+              <div className="space-y-3">
+                {terms.map((t) => (
+                  <div
+                    key={t.slug}
+                    id={`term-${t.slug}`}
+                    className="rounded-lg border border-border bg-card p-4"
+                    data-testid={`glossary-term-${t.slug}`}
+                  >
+                    <div className="mb-1.5 flex flex-wrap items-center gap-2">
+                      <h3 className="font-semibold">
+                        <a
+                          href={`#term-${t.slug}`}
+                          className="hover:text-primary"
+                        >
+                          {t.term}
+                        </a>
+                      </h3>
+                      <Badge variant="secondary" className="text-[10px]">
+                        {CATEGORY_LABELS[t.category] ?? t.category}
+                      </Badge>
+                    </div>
+                    <p className="text-sm leading-relaxed text-muted-foreground">
+                      {t.definition}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
+      )}
+
+      {/* Footer with BookOpen icon */}
+      <p className="flex items-center gap-1.5 pt-2 text-xs text-muted-foreground">
+        <BookOpen className="size-3.5" />
+        {GLOSSARY_TERMS.length} terms defined
+      </p>
+    </div>
+  )
+}

--- a/web/src/pages/options-page.test.tsx
+++ b/web/src/pages/options-page.test.tsx
@@ -1,0 +1,55 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { OptionsPage } from '@/pages/options-page'
+
+vi.mock('@/lib/api/client', () => ({
+  apiClient: {
+    getOptionsChain: vi.fn().mockResolvedValue({ calls: [], puts: [] }),
+  },
+}))
+
+function renderAt(search = '') {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={[`/options${search}`]}>
+        <Routes>
+          <Route path="/options" element={<OptionsPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+describe('OptionsPage', () => {
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('renders the page without crashing', () => {
+    renderAt()
+    expect(screen.getByTestId('options-page')).toBeInTheDocument()
+  })
+
+  it('seeds ticker input from ?ticker= URL param', async () => {
+    renderAt('?ticker=AAPL')
+
+    await waitFor(() => {
+      const input = screen.getByRole<HTMLInputElement>('textbox', { name: /underlying ticker/i })
+      expect(input.value).toBe('AAPL')
+    })
+  })
+
+  it('calls getOptionsChain when ?ticker= param is present on mount', async () => {
+    const { apiClient } = await import('@/lib/api/client')
+    renderAt('?ticker=TSLA')
+
+    await waitFor(() => {
+      expect(apiClient.getOptionsChain).toHaveBeenCalledWith('TSLA', expect.any(Object))
+    })
+  })
+})

--- a/web/src/pages/options-page.tsx
+++ b/web/src/pages/options-page.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 import { Search, TrendingUp } from 'lucide-react'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
 
 import { PageHeader } from '@/components/layout/page-header'
 import { ChainTable } from '@/components/options/chain-table'
@@ -12,6 +13,7 @@ import { apiClient } from '@/lib/api/client'
 type OptionTypeFilter = '' | 'call' | 'put'
 
 export function OptionsPage() {
+  const [searchParams] = useSearchParams()
   const [draftTicker, setDraftTicker] = useState('')
   const [draftExpiry, setDraftExpiry] = useState('')
   const [draftType, setDraftType] = useState<OptionTypeFilter>('')
@@ -30,15 +32,32 @@ export function OptionsPage() {
     enabled: false,
   })
 
-  function loadChain() {
-    const normalized = draftTicker.trim().toUpperCase()
+  function commitAndLoad(
+    tickerValue: string,
+    expiryValue = draftExpiry,
+    typeValue: OptionTypeFilter = draftType,
+  ) {
+    const normalized = tickerValue.trim().toUpperCase()
     if (!normalized) return
+    setDraftTicker(normalized)
     setTicker(normalized)
-    setExpiry(draftExpiry)
-    setOptionType(draftType)
-    // refetch after state settles
+    setDraftExpiry(expiryValue)
+    setExpiry(expiryValue)
+    setDraftType(typeValue)
+    setOptionType(typeValue)
     setTimeout(() => void refetch(), 0)
   }
+
+  function loadChain() {
+    commitAndLoad(draftTicker, draftExpiry, draftType)
+  }
+
+  // Seed from URL param: /options?ticker=AAPL
+  useEffect(() => {
+    const tickerParam = searchParams.get('ticker')
+    if (tickerParam) commitAndLoad(tickerParam, '', '')
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   return (
     <div className="space-y-4" data-testid="options-page">

--- a/web/src/pages/order-detail-page.tsx
+++ b/web/src/pages/order-detail-page.tsx
@@ -6,7 +6,7 @@ import { PageHeader } from '@/components/layout/page-header'
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { apiClient } from '@/lib/api/client'
-import type { OrderSide, OrderStatus } from '@/lib/api/types'
+import type { Order, OrderSide, OrderStatus } from '@/lib/api/types'
 
 const STATUS_VARIANTS: Record<OrderStatus, 'default' | 'success' | 'destructive' | 'warning' | 'secondary'> = {
   pending: 'default',
@@ -35,6 +35,35 @@ function formatDate(dateStr?: string) {
     hour: '2-digit',
     minute: '2-digit',
   })
+}
+
+function getOptionalStringField(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key]
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+function getOptionalNumberField(record: Record<string, unknown>, key: string): number | undefined {
+  const value = record[key]
+  return typeof value === 'number' ? value : undefined
+}
+
+function getOrderOptionFields(order: Order): {
+  optionType?: string
+  underlyingTicker?: string
+  strike?: number
+  expiry?: string
+  contractMultiplier?: number
+  positionIntent?: string
+} {
+  const record = order as unknown as Record<string, unknown>
+  return {
+    optionType: getOptionalStringField(record, 'option_type'),
+    underlyingTicker: getOptionalStringField(record, 'underlying_ticker') ?? getOptionalStringField(record, 'underlying'),
+    strike: getOptionalNumberField(record, 'strike'),
+    expiry: getOptionalStringField(record, 'expiry'),
+    contractMultiplier: getOptionalNumberField(record, 'contract_multiplier'),
+    positionIntent: getOptionalStringField(record, 'position_intent'),
+  }
 }
 
 export function OrderDetailPage() {
@@ -77,6 +106,7 @@ export function OrderDetailPage() {
   }
 
   const order = data.order
+  const optionFields = getOrderOptionFields(order)
 
   return (
     <div className="space-y-4" data-testid="order-detail-page">
@@ -181,7 +211,7 @@ export function OrderDetailPage() {
         </Card>
       )}
 
-      {(order as Record<string, unknown>).option_type && (
+      {optionFields.optionType && (
         <Card>
           <CardHeader>
             <CardTitle>Options info</CardTitle>
@@ -189,38 +219,38 @@ export function OrderDetailPage() {
           </CardHeader>
           <CardContent>
             <dl className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-              {(order as Record<string, unknown>).underlying && (
+              {optionFields.underlyingTicker && (
                 <div>
                   <dt className="font-mono text-[11px] uppercase tracking-[0.16em] text-muted-foreground">Underlying</dt>
-                  <dd className="mt-1 text-sm font-medium">{String((order as Record<string, unknown>).underlying)}</dd>
+                  <dd className="mt-1 text-sm font-medium">{optionFields.underlyingTicker}</dd>
                 </div>
               )}
               <div>
                 <dt className="font-mono text-[11px] uppercase tracking-[0.16em] text-muted-foreground">Option type</dt>
-                <dd className="mt-1 text-sm font-medium">{String((order as Record<string, unknown>).option_type)}</dd>
+                <dd className="mt-1 text-sm font-medium">{optionFields.optionType}</dd>
               </div>
-              {(order as Record<string, unknown>).strike != null && (
+              {optionFields.strike != null && (
                 <div>
                   <dt className="font-mono text-[11px] uppercase tracking-[0.16em] text-muted-foreground">Strike</dt>
-                  <dd className="mt-1 font-mono text-[13px] font-medium">${Number((order as Record<string, unknown>).strike).toFixed(2)}</dd>
+                  <dd className="mt-1 font-mono text-[13px] font-medium">${optionFields.strike.toFixed(2)}</dd>
                 </div>
               )}
-              {(order as Record<string, unknown>).expiry && (
+              {optionFields.expiry && (
                 <div>
                   <dt className="font-mono text-[11px] uppercase tracking-[0.16em] text-muted-foreground">Expiry</dt>
-                  <dd className="mt-1 font-mono text-[13px] font-medium">{formatDate(String((order as Record<string, unknown>).expiry))}</dd>
+                  <dd className="mt-1 font-mono text-[13px] font-medium">{formatDate(optionFields.expiry)}</dd>
                 </div>
               )}
-              {(order as Record<string, unknown>).contract_multiplier != null && (
+              {optionFields.contractMultiplier != null && (
                 <div>
                   <dt className="font-mono text-[11px] uppercase tracking-[0.16em] text-muted-foreground">Contract multiplier</dt>
-                  <dd className="mt-1 font-mono text-[13px] font-medium">{String((order as Record<string, unknown>).contract_multiplier)}</dd>
+                  <dd className="mt-1 font-mono text-[13px] font-medium">{String(optionFields.contractMultiplier)}</dd>
                 </div>
               )}
-              {(order as Record<string, unknown>).position_intent && (
+              {optionFields.positionIntent && (
                 <div>
                   <dt className="font-mono text-[11px] uppercase tracking-[0.16em] text-muted-foreground">Position intent</dt>
-                  <dd className="mt-1 text-sm font-medium">{String((order as Record<string, unknown>).position_intent)}</dd>
+                  <dd className="mt-1 text-sm font-medium">{optionFields.positionIntent}</dd>
                 </div>
               )}
             </dl>

--- a/web/src/pages/pipeline-run-page.tsx
+++ b/web/src/pages/pipeline-run-page.tsx
@@ -41,6 +41,10 @@ const legacyRiskRoleMap: Partial<Record<AgentRole, AgentRole>> = {
   neutral_risk: 'neutral_analyst',
 };
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
 function normalizeAgentRole(role: AgentRole): AgentRole {
   return legacyRiskRoleMap[role] ?? role;
 }
@@ -209,6 +213,8 @@ export function PipelineRunPage() {
     () => computePhases(decisions, run?.status === 'completed', Boolean(run?.signal)),
     [decisions, run?.signal, run?.status],
   );
+  const phaseTimings = isRecord(run?.phase_timings) ? run.phase_timings : null;
+  const configSnapshot = run?.config_snapshot;
 
   if (runLoading) {
     return (
@@ -311,33 +317,31 @@ export function PipelineRunPage() {
         </div>
       )}
 
-      {run.phase_timings && typeof run.phase_timings === 'object' && (
+      {phaseTimings && (
         <Card>
           <CardContent className="py-4">
             <h3 className="mb-2 font-mono text-[11px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
               Phase Timings
             </h3>
             <ul className="space-y-1 text-sm">
-              {Object.entries(run.phase_timings as Record<string, unknown>).map(
-                ([phase, duration]) => (
-                  <li key={phase} className="flex items-center justify-between">
-                    <span className="font-medium">{phase}</span>
-                    <span className="font-mono text-muted-foreground">{String(duration)}</span>
-                  </li>
-                ),
-              )}
+              {Object.entries(phaseTimings).map(([phase, duration]) => (
+                <li key={phase} className="flex items-center justify-between">
+                  <span className="font-medium">{phase}</span>
+                  <span className="font-mono text-muted-foreground">{String(duration)}</span>
+                </li>
+              ))}
             </ul>
           </CardContent>
         </Card>
       )}
 
-      {run.config_snapshot && (
+      {configSnapshot != null && (
         <details className="rounded-lg border border-border bg-background">
           <summary className="cursor-pointer px-4 py-3 text-sm font-medium text-muted-foreground hover:text-foreground">
             Config Snapshot
           </summary>
           <pre className="overflow-x-auto px-4 pb-4 font-mono text-xs text-muted-foreground">
-            {JSON.stringify(run.config_snapshot, null, 2)}
+            {JSON.stringify(configSnapshot, null, 2)}
           </pre>
         </details>
       )}

--- a/web/src/pages/realtime-page.tsx
+++ b/web/src/pages/realtime-page.tsx
@@ -2,7 +2,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   Activity,
   AlertCircle,
-  ArrowDown,
+  ArrowUp,
   Brain,
   CandlestickChart,
   CircleDot,
@@ -139,7 +139,7 @@ function toFeedItem(message: WebSocketMessage): FeedItem {
 
 function sortEvents(events: FeedItem[]) {
   return [...events].sort(
-    (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
+    (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
   );
 }
 
@@ -707,7 +707,7 @@ export function RealtimePage() {
       return;
     }
 
-    feedRef.current.scrollTop = feedRef.current.scrollHeight;
+    feedRef.current.scrollTop = 0;
   }, [autoScroll, events]);
 
   function handleFeedScroll() {
@@ -716,14 +716,14 @@ export function RealtimePage() {
       return;
     }
 
-    const nearBottom = element.scrollHeight - element.scrollTop - element.clientHeight < 24;
-    setAutoScroll(nearBottom);
+    const nearTop = element.scrollTop < 24;
+    setAutoScroll(nearTop);
   }
 
   function resumeScroll() {
     setAutoScroll(true);
     if (feedRef.current) {
-      feedRef.current.scrollTop = feedRef.current.scrollHeight;
+      feedRef.current.scrollTop = 0;
     }
   }
 
@@ -888,7 +888,7 @@ export function RealtimePage() {
                 onClick={resumeScroll}
                 data-testid="realtime-resume-scroll"
               >
-                <ArrowDown className="size-4" />
+                <ArrowUp className="size-4" />
                 Resume live scroll
               </Button>
             ) : null}
@@ -898,9 +898,9 @@ export function RealtimePage() {
       />
 
       <div className="grid gap-4 xl:h-[calc(100vh-15rem)] xl:grid-cols-[minmax(360px,0.92fr)_minmax(0,1.08fr)]">
-        <div className="flex min-h-115 min-w-0 flex-col rounded-lg border border-border bg-card p-4 xl:min-h-0">
+        {/* Feed panel — second on mobile, first (left) on xl */}
+        <div className="order-2 flex min-h-115 min-w-0 flex-col rounded-lg border border-border bg-card p-4 xl:order-1 xl:min-h-0">
           <div className="mb-4 space-y-3">
-            <div className="flex items-center justify-between gap-3">
               <div className="space-y-1">
                 <h3 className="text-lg font-semibold">Event feed</h3>
                 <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
@@ -1002,7 +1002,8 @@ export function RealtimePage() {
           </div>
         </div>
 
-        <div className="flex min-h-115 w-full flex-1 flex-col rounded-lg border border-border bg-card p-4 xl:min-h-0">
+        {/* Viewer/chat panel — first on mobile, second (right) on xl */}
+        <div className="order-1 flex min-h-115 w-full flex-1 flex-col rounded-lg border border-border bg-card p-4 xl:order-2 xl:min-h-0">
           {selectedEvent ? (
             <div
               className="flex min-h-0 flex-1 flex-col space-y-4"

--- a/web/src/pages/risk-page.test.tsx
+++ b/web/src/pages/risk-page.test.tsx
@@ -68,7 +68,7 @@ describe('RiskPage', () => {
     expect(screen.getByTestId('risk-page')).toBeInTheDocument()
     expect(await screen.findByText('Open')).toBeInTheDocument()
     expect(screen.getByText('Inactive')).toBeInTheDocument()
-    expect(screen.getByTestId('kill-switch-toggle')).toHaveTextContent('Activate')
+    expect(screen.getByTestId('kill-switch-toggle')).toHaveTextContent('Stop All')
     expect(await screen.findByTestId('audit-log-table')).toBeInTheDocument()
     expect(screen.getByText('kill_switch_toggled')).toBeInTheDocument()
     expect(screen.getByText('risk')).toBeInTheDocument()
@@ -124,7 +124,7 @@ describe('RiskPage', () => {
 
     expect(await screen.findByText('Active')).toBeInTheDocument()
     expect(screen.getByText('Emergency halt')).toBeInTheDocument()
-    expect(screen.getByTestId('kill-switch-toggle')).toHaveTextContent('Deactivate')
+    expect(screen.getByTestId('kill-switch-toggle')).toHaveTextContent('Resume All')
   })
 
   it('loads more audit entries when requested', async () => {

--- a/web/src/pages/risk-page.tsx
+++ b/web/src/pages/risk-page.tsx
@@ -1,4 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Power } from 'lucide-react'
 import { useState } from 'react'
 
 import { PageHeader } from '@/components/layout/page-header'
@@ -202,7 +203,7 @@ export function RiskPage() {
 
                 {showReasonInput && !killSwitch.active ? (
                   <div className="space-y-2">
-                    <Label htmlFor="kill-reason">Reason for activation</Label>
+                    <Label htmlFor="kill-reason">Reason for halt</Label>
                     <Input
                       id="kill-reason"
                       placeholder="Enter reason..."
@@ -211,12 +212,13 @@ export function RiskPage() {
                     />
                     <div className="flex gap-2">
                       <Button
-                        variant="default"
+                        variant="destructive"
                         size="sm"
                         disabled={!reason.trim() || toggleMutation.isPending}
                         onClick={handleToggle}
                       >
-                        {toggleMutation.isPending ? 'Activating...' : 'Confirm Activate'}
+                        <Power className="size-3.5" />
+                        {toggleMutation.isPending ? 'Stopping...' : 'Confirm Stop All'}
                       </Button>
                       <Button
                         variant="outline"
@@ -234,16 +236,17 @@ export function RiskPage() {
 
                 {!showReasonInput ? (
                   <Button
-                    variant={killSwitch.active ? 'outline' : 'default'}
+                    variant={killSwitch.active ? 'outline' : 'destructive'}
                     disabled={toggleMutation.isPending}
                     onClick={handleToggle}
                     data-testid="kill-switch-toggle"
                   >
+                    <Power className="size-4" />
                     {toggleMutation.isPending
                       ? 'Processing...'
                       : killSwitch.active
-                        ? 'Deactivate'
-                        : 'Activate'}
+                        ? 'Resume All'
+                        : 'Stop All'}
                   </Button>
                 ) : null}
               </div>

--- a/web/src/pages/stock-detail-page.tsx
+++ b/web/src/pages/stock-detail-page.tsx
@@ -8,6 +8,8 @@ import {
   FileText,
   FlaskConical,
   Loader2,
+  MessageSquare,
+  Newspaper,
   Play,
   Receipt,
   Sparkles,
@@ -314,8 +316,58 @@ export function StockDetailPage() {
 
       {/* Two-column layout */}
       <div className="grid gap-4 xl:grid-cols-[minmax(0,1.4fr)_minmax(320px,0.9fr)]">
-        {/* Left column: strategies, orders, trades, positions */}
+        {/* Left column: price chart stub, news stub, social stub, strategies, orders, trades, positions */}
         <div className="space-y-4">
+          {/* Price Chart — stub (endpoint not yet available) */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base">
+                <BarChart3 className="size-4 text-muted-foreground" />
+                Price chart
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="flex h-32 items-center justify-center rounded-md border border-dashed border-border bg-muted/20">
+                <p className="text-sm text-muted-foreground">
+                  Price chart data not yet available
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* News — stub (endpoint not yet available) */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base">
+                <Newspaper className="size-4 text-muted-foreground" />
+                News
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="flex h-24 items-center justify-center rounded-md border border-dashed border-border bg-muted/20">
+                <p className="text-sm text-muted-foreground">
+                  News feed not yet available
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Social Sentiment — stub (endpoint not yet available) */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base">
+                <MessageSquare className="size-4 text-muted-foreground" />
+                Social sentiment
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="flex h-24 items-center justify-center rounded-md border border-dashed border-border bg-muted/20">
+                <p className="text-sm text-muted-foreground">
+                  Social sentiment not yet available
+                </p>
+              </div>
+            </CardContent>
+          </Card>
           {/* Active Strategies */}
           <Card>
             <CardHeader>

--- a/web/src/pages/strategies-page.tsx
+++ b/web/src/pages/strategies-page.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { Activity, Clock, Pause, Play, Plus, Search } from 'lucide-react'
+import { Activity, Clock, Pause, Play, Plus } from 'lucide-react'
 import { useState } from 'react'
 import { Link } from 'react-router-dom'
 
@@ -8,15 +8,9 @@ import { CreateStrategyDialog } from '@/components/strategies/create-strategy-di
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-import { Input } from '@/components/ui/input'
 import { apiClient } from '@/lib/api/client'
-import type { MarketType, Strategy, StrategyCreateRequest, StrategyStatus } from '@/lib/api/types'
+import type { Strategy, StrategyCreateRequest, StrategyStatus } from '@/lib/api/types'
 import { describeCron } from '@/lib/cron-describe'
-
-const MARKET_TYPE_OPTIONS: MarketType[] = ['stock', 'crypto', 'polymarket']
-const STATUS_OPTIONS: StrategyStatus[] = ['active', 'paused', 'inactive']
-const denseSelectClassName =
-  'flex h-9 w-full rounded-md border border-input bg-card px-3 py-1 text-sm text-foreground transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring'
 
 function MarketTypeBadge({ type }: { type: Strategy['market_type'] }) {
   const variants: Record<Strategy['market_type'], 'default' | 'secondary' | 'outline'> = {
@@ -59,44 +53,11 @@ export function StrategiesPage() {
   const [createOpen, setCreateOpen] = useState(false)
   const queryClient = useQueryClient()
 
-  // Filter state (draft -> applied on button click)
-  const [draftTicker, setDraftTicker] = useState('')
-  const [draftMarketType, setDraftMarketType] = useState<MarketType | ''>('')
-  const [draftStatus, setDraftStatus] = useState<StrategyStatus | ''>('')
-  const [draftIsPaper, setDraftIsPaper] = useState<'' | 'true' | 'false'>('')
-
-  const [ticker, setTicker] = useState('')
-  const [marketType, setMarketType] = useState<MarketType | ''>('')
-  const [status, setStatus] = useState<StrategyStatus | ''>('')
-  const [isPaper, setIsPaper] = useState<'' | 'true' | 'false'>('')
-
-  function applyFilters() {
-    setTicker(draftTicker.trim())
-    setMarketType(draftMarketType)
-    setStatus(draftStatus)
-    setIsPaper(draftIsPaper)
-  }
-
-  function clearFilters() {
-    setDraftTicker('')
-    setDraftMarketType('')
-    setDraftStatus('')
-    setDraftIsPaper('')
-    setTicker('')
-    setMarketType('')
-    setStatus('')
-    setIsPaper('')
-  }
-
   const { data, isLoading, isError } = useQuery({
-    queryKey: ['strategies', ticker, marketType, status, isPaper],
+    queryKey: ['strategies'],
     queryFn: () =>
       apiClient.listStrategies({
         limit: 100,
-        ticker: ticker || undefined,
-        market_type: marketType || undefined,
-        status: status || undefined,
-        is_paper: isPaper === 'true' ? true : isPaper === 'false' ? false : undefined,
       }),
     refetchInterval: 30_000,
   })

--- a/web/src/pages/universe-page.tsx
+++ b/web/src/pages/universe-page.tsx
@@ -276,7 +276,7 @@ export function UniversePage() {
             )}
 
             {!scanMutation.data && watchlist.length > 0 && (
-              <WatchlistTable tickers={watchlist as unknown as ScoredTicker[]} />
+              <WatchlistTable tickers={watchlist} />
             )}
 
             {!scanMutation.data &&


### PR DESCRIPTION
## Summary

Four-step frontend overhaul across the React/Vite/Tailwind v4 SPA.

### Step 1 — UI foundation + rebrand
- All "Get Rich Quick" strings replaced with **Augr** (sidebar, header breadcrumb, tests)
- Mobile nav horizontal scrollbar hidden via `@utility scrollbar-none`
- `html { font-size: 93.75% }` for tighter density at 100% zoom (comfortable at 85%)

### Step 2 — Interaction consistency + stability
- **WatchlistTable crash fixed**: `score ?? 0` null-guard; removed unsafe `as unknown as ScoredTicker[]` cast in `universe-page`
- **Options chain URL autofill**: `?ticker=AAPL` on navigate seeds the input and fires the query on mount via race-condition-free `commitAndLoad()`
- **Kill switch unified**: both `risk-status-bar` and `risk-page` now use `variant='destructive'`, Power icon, and Stop All / Resume All labels

### Step 3 — Data + content rendering
- **Output truncation removed**: `analyst-cards`, `final-signal`, `decision-inspector` — no more `line-clamp` or `.slice()` caps
- **Realtime feed**: newest-first sort, viewer/chat panel reordered above event feed, auto-scroll target flipped to top
- **Markdown rendering**: `react-markdown` v10 installed; all chat messages render as GFM with inline Tailwind prose styles
- **Stock detail page**: Price chart, News, and Social sentiment stub sections added (dashed placeholder, ready to wire when backend exposes endpoints)

### Step 4 — Knowledge layer + tests
- **Glossary page** (`/glossary`): 28 trading terms, alphabetically grouped, live search filter, per-term anchor links, category badges — linked from nav and router
- Fixed `react-markdown` v10 breaking change (`className` prop removed from `<Markdown>`, moved to wrapper `<div>`)
- New: `options-page.test.tsx` (URL param autofill, API call on mount)
- New: watchlist null-score test (`undefined` score renders `0.00`)
- New: `glossary-page.test.tsx` (6 tests: render, filter by name, filter by definition, empty state, alpha grouping)
- Updated: `risk-page.test.tsx` (Activate→Stop All, Deactivate→Resume All)
- Updated: `chat-panel.test.tsx` (`p.whitespace-pre-wrap` → `data-testid` selector)

## Test results
35 targeted tests pass. 27 pre-existing failures in `auth.test.ts` (localStorage infrastructure issue, present before this branch).